### PR TITLE
Add custom/self-hosted LLM provider

### DIFF
--- a/src/components/onboarding/StepLLM.tsx
+++ b/src/components/onboarding/StepLLM.tsx
@@ -13,7 +13,7 @@ import {
   Title,
 } from "./primitives";
 import { SECRET_KEYS, getSecret, setSecret } from "../../services/secrets";
-import { getProvider, type LLMProviderId } from "../../services/llm";
+import { getProvider, setCustomConfig, type LLMProviderId } from "../../services/llm";
 import { getConfig, setConfig, upsertIntegration } from "../../services/db";
 
 const PROVIDERS: Array<{
@@ -34,6 +34,10 @@ const PROVIDERS: Array<{
     id: "openrouter",
     blurb: "Gateway — any model, one key. Useful behind a corporate egress.",
   },
+  {
+    id: "custom",
+    blurb: "Any OpenAI-compatible endpoint — Ollama, vLLM, LM Studio, etc.",
+  },
 ];
 
 export function StepLLM({ onNext }: { onNext: () => void }) {
@@ -41,6 +45,9 @@ export function StepLLM({ onNext }: { onNext: () => void }) {
   const [key, setKey] = useState("");
   const [state, setState] = useState<"idle" | "testing" | "ok" | "err">("idle");
   const [error, setError] = useState("");
+  const [customBaseUrl, setCustomBaseUrl] = useState("");
+  const [customSynthModel, setCustomSynthModel] = useState("");
+  const [customClassModel, setCustomClassModel] = useState("");
 
   useEffect(() => {
     (async () => {
@@ -48,6 +55,9 @@ export function StepLLM({ onNext }: { onNext: () => void }) {
       if (cfg.llm_provider) setProvider(cfg.llm_provider);
       const existing = await getSecret(SECRET_KEYS[cfg.llm_provider || "anthropic"]);
       if (existing) setKey(existing);
+      if (cfg.custom_llm_base_url) setCustomBaseUrl(cfg.custom_llm_base_url);
+      if (cfg.custom_llm_synthesis_model) setCustomSynthModel(cfg.custom_llm_synthesis_model);
+      if (cfg.custom_llm_classifier_model) setCustomClassModel(cfg.custom_llm_classifier_model);
     })();
   }, []);
 
@@ -67,29 +77,56 @@ export function StepLLM({ onNext }: { onNext: () => void }) {
     setState("testing");
     setError("");
     const trimmed = key.trim();
-    // Format pre-check — catches the common "pasted from the wrong page"
-    // failure mode (e.g. copying from claude.ai or a dashboard session
-    // cookie instead of console.anthropic.com/settings/keys).
-    const formatProblem = keyFormatProblem(provider, trimmed);
-    if (formatProblem) {
-      setState("err");
-      setError(formatProblem);
-      return;
+
+    if (provider === "custom") {
+      if (!customBaseUrl.trim()) {
+        setState("err");
+        setError("Enter a base URL for your endpoint (e.g. http://localhost:11434).");
+        return;
+      }
+      if (!customSynthModel.trim() || !customClassModel.trim()) {
+        setState("err");
+        setError("Enter both a synthesis model and a classifier model name.");
+        return;
+      }
+      // Configure the custom provider before testing.
+      setCustomConfig({
+        base_url: customBaseUrl.trim(),
+        synthesis_model: customSynthModel.trim(),
+        classifier_model: customClassModel.trim(),
+      });
+    } else {
+      // Format pre-check — catches the common "pasted from the wrong page"
+      // failure mode (e.g. copying from claude.ai or a dashboard session
+      // cookie instead of console.anthropic.com/settings/keys).
+      const formatProblem = keyFormatProblem(provider, trimmed);
+      if (formatProblem) {
+        setState("err");
+        setError(formatProblem);
+        return;
+      }
     }
+
     try {
       // Verify the key against the provider FIRST, bypassing the keychain
       // so we can (a) avoid a get-after-set race in unsigned macOS dev
       // builds and (b) never persist a key that doesn't work.
-      const ok = await p.test(trimmed);
+      const ok = await p.test(trimmed || undefined);
       if (!ok) throw new Error("Test call did not return a success.");
       // Test passed — persist and record the integration.
-      await setSecret(SECRET_KEYS[provider], trimmed);
+      if (trimmed) await setSecret(SECRET_KEYS[provider], trimmed);
       await upsertIntegration(provider, {});
-      await setConfig({
+      const configPatch: Record<string, any> = {
         llm_provider: provider,
-        synthesis_model: p.defaultSynthesisModel,
-        classifier_model: p.defaultClassifierModel,
-      });
+        synthesis_model: provider === "custom" ? customSynthModel.trim() : p.defaultSynthesisModel,
+        classifier_model: provider === "custom" ? customClassModel.trim() : p.defaultClassifierModel,
+      };
+      if (provider === "custom") {
+        configPatch.custom_llm_base_url = customBaseUrl.trim();
+        configPatch.custom_llm_synthesis_model = customSynthModel.trim();
+        configPatch.custom_llm_classifier_model = customClassModel.trim();
+      }
+      await setConfig(configPatch);
       setState("ok");
     } catch (e: any) {
       setState("err");
@@ -104,8 +141,21 @@ export function StepLLM({ onNext }: { onNext: () => void }) {
         Keepr uses your own API key. Nothing routes through a middleman —
         your data goes directly from this laptop to the provider you pick.
       </Lede>
+      <p className="mb-4 text-xxs leading-snug text-ink-faint">
+        Have a Claude Pro subscription? You still need a separate API key from{" "}
+        <button
+          className="text-accent hover:underline"
+          onClick={(e) => {
+            e.preventDefault();
+            openExternal("https://console.anthropic.com/settings/keys");
+          }}
+        >
+          console.anthropic.com
+        </button>
+        {" "}— Pro subscriptions don't include API access.
+      </p>
 
-      <div className="mb-6 grid grid-cols-3 gap-2">
+      <div className="mb-6 grid grid-cols-4 gap-2">
         {PROVIDERS.map((row) => {
           const active = provider === row.id;
           return (
@@ -134,33 +184,67 @@ export function StepLLM({ onNext }: { onNext: () => void }) {
         })}
       </div>
 
-      <Field
-        label={`${p.label} API key`}
-        hint={
-          <>
-            Don't have one?{" "}
-            <button
-              className="text-accent hover:underline"
-              onClick={(e) => {
-                e.preventDefault();
-                openExternal(p.keyUrl);
-              }}
-            >
-              Create one at {new URL(p.keyUrl).host}
-            </button>
-          </>
-        }
-      >
-        <Input
-          type="password"
-          placeholder="sk-…"
-          value={key}
-          onChange={(e) => {
-            setKey(e.target.value);
-            if (state !== "idle") setState("idle");
-          }}
-        />
-      </Field>
+      {provider === "custom" ? (
+        <>
+          <Field label="Base URL" hint="The root URL of your OpenAI-compatible server (e.g. http://localhost:11434)">
+            <Input
+              placeholder="http://localhost:11434"
+              value={customBaseUrl}
+              onChange={(e) => { setCustomBaseUrl(e.target.value); if (state !== "idle") setState("idle"); }}
+            />
+          </Field>
+          <Field label="Synthesis model" hint="The larger model for final output (e.g. llama3.1:70b, mistral-large)">
+            <Input
+              placeholder="llama3.1:70b"
+              value={customSynthModel}
+              onChange={(e) => { setCustomSynthModel(e.target.value); if (state !== "idle") setState("idle"); }}
+            />
+          </Field>
+          <Field label="Classifier model" hint="A fast/cheap model for the first-pass summaries (e.g. llama3.1:8b, phi3)">
+            <Input
+              placeholder="llama3.1:8b"
+              value={customClassModel}
+              onChange={(e) => { setCustomClassModel(e.target.value); if (state !== "idle") setState("idle"); }}
+            />
+          </Field>
+          <Field label="API key (optional)" hint="Leave blank if your endpoint doesn't require auth">
+            <Input
+              type="password"
+              placeholder="optional"
+              value={key}
+              onChange={(e) => { setKey(e.target.value); if (state !== "idle") setState("idle"); }}
+            />
+          </Field>
+        </>
+      ) : (
+        <Field
+          label={`${p.label} API key`}
+          hint={
+            <>
+              Don't have one?{" "}
+              <button
+                className="text-accent hover:underline"
+                onClick={(e) => {
+                  e.preventDefault();
+                  openExternal(p.keyUrl);
+                }}
+              >
+                Create one at {new URL(p.keyUrl).host}
+              </button>
+            </>
+          }
+        >
+          <Input
+            type="password"
+            placeholder="sk-…"
+            value={key}
+            onChange={(e) => {
+              setKey(e.target.value);
+              if (state !== "idle") setState("idle");
+            }}
+          />
+        </Field>
+      )}
 
       <StepFooter
         right={
@@ -171,7 +255,7 @@ export function StepLLM({ onNext }: { onNext: () => void }) {
       >
         <PrimaryButton
           onClick={test}
-          disabled={!key.trim() || state === "testing"}
+          disabled={(provider !== "custom" && !key.trim()) || state === "testing"}
         >
           {state === "testing" ? "Testing…" : "Test & save"}
         </PrimaryButton>
@@ -192,6 +276,7 @@ function keyFormatProblem(
   provider: LLMProviderId,
   key: string
 ): string | null {
+  if (provider === "custom") return null;
   if (!key) return "Paste your API key to continue.";
   if (/\s/.test(key)) return "That key has whitespace in it — try copying again.";
   if (key.length < 20) return "That looks too short to be an API key.";
@@ -220,6 +305,9 @@ function friendlyProviderError(e: any, provider: LLMProviderId): string {
   if (raw.includes("401") || raw.includes("unauthorized") || raw.includes("invalid_api_key") || raw.includes("invalid x-api-key")) {
     if (provider === "anthropic") {
       return "Anthropic rejected that key (401). Possible causes: (1) the key was deactivated, (2) the account has no API billing set up at platform.claude.com/settings/billing, (3) you copied a truncated key. Check the DevTools console for the raw response and try creating a fresh key.";
+    }
+    if (provider === "custom") {
+      return "Your endpoint returned 401 — check the API key or auth configuration.";
     }
     const host = new URL(getProvider(provider).keyUrl).host;
     return `That key didn't authorize. Double-check you copied it from ${host}.`;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,6 +1,6 @@
 // Shared domain types for Keepr.
 
-export type Provider = "slack" | "github" | "jira" | "linear" | "anthropic" | "openai" | "openrouter";
+export type Provider = "slack" | "github" | "jira" | "linear" | "anthropic" | "openai" | "openrouter" | "custom";
 export type WorkflowType = "team_pulse" | "one_on_one_prep" | "weekly_update" | "perf_evaluation" | "promo_readiness";
 export type SessionStatus = "pending" | "processing" | "complete" | "failed";
 export type EvidenceSource = "github_pr" | "github_review" | "slack_message" | "jira_issue" | "jira_comment" | "linear_issue" | "linear_comment";
@@ -77,9 +77,12 @@ export interface AppConfig {
   selected_jira_projects: JiraProject[];
   selected_linear_teams: LinearTeam[];
   jira_cloud_url: string;
-  llm_provider: "anthropic" | "openai" | "openrouter";
+  llm_provider: "anthropic" | "openai" | "openrouter" | "custom";
   synthesis_model: string;
   classifier_model: string;
+  custom_llm_base_url: string;
+  custom_llm_synthesis_model: string;
+  custom_llm_classifier_model: string;
   privacy_consent_at: string | null;
   onboarded_at: string | null;
   engineering_rubric: string | null;
@@ -95,6 +98,9 @@ export const DEFAULT_CONFIG: AppConfig = {
   llm_provider: "anthropic",
   synthesis_model: "claude-sonnet-4-6",
   classifier_model: "claude-haiku-4-5-20251001",
+  custom_llm_base_url: "",
+  custom_llm_synthesis_model: "",
+  custom_llm_classifier_model: "",
   privacy_consent_at: null,
   onboarded_at: null,
   engineering_rubric: null,

--- a/src/screens/Settings.tsx
+++ b/src/screens/Settings.tsx
@@ -12,7 +12,7 @@ import {
   deleteMember,
 } from "../services/db";
 import { SECRET_KEYS, getSecret, setSecret } from "../services/secrets";
-import { getProvider, type LLMProviderId } from "../services/llm";
+import { getProvider, setCustomConfig, type LLMProviderId } from "../services/llm";
 import { defaultMemoryDir } from "../services/fsio";
 import { slugify } from "../services/memory";
 import * as slack from "../services/slack";
@@ -94,16 +94,23 @@ export function Settings() {
 
         <Panel title="Model">
           <div className="mb-3 flex gap-2">
-            {(["anthropic", "openai", "openrouter"] as LLMProviderId[]).map((id) => (
+            {(["anthropic", "openai", "openrouter", "custom"] as LLMProviderId[]).map((id) => (
               <button
                 key={id}
                 onClick={async () => {
                   const p = getProvider(id);
-                  await setConfig({
+                  const patch: Record<string, any> = {
                     llm_provider: id,
-                    synthesis_model: p.defaultSynthesisModel,
-                    classifier_model: p.defaultClassifierModel,
-                  });
+                  };
+                  if (id === "custom") {
+                    // For custom, use the stored custom model names (or keep current).
+                    patch.synthesis_model = cfg.custom_llm_synthesis_model || cfg.synthesis_model;
+                    patch.classifier_model = cfg.custom_llm_classifier_model || cfg.classifier_model;
+                  } else {
+                    patch.synthesis_model = p.defaultSynthesisModel;
+                    patch.classifier_model = p.defaultClassifierModel;
+                  }
+                  await setConfig(patch);
                   // load() will read the key for the newly-active provider.
                   await load();
                 }}
@@ -120,6 +127,70 @@ export function Settings() {
           {(() => {
             const activeProvider = (cfg.llm_provider || "anthropic") as LLMProviderId;
             const p = getProvider(activeProvider);
+
+            const saveKey = async () => {
+              try {
+                await setSecret(SECRET_KEYS[activeProvider], llmKey.trim());
+                const readBack = await getSecret(SECRET_KEYS[activeProvider]);
+                if (readBack !== llmKey.trim()) {
+                  throw new Error("Key did not persist (keychain read-back mismatch)");
+                }
+                if (activeProvider === "custom") {
+                  await setConfig({
+                    custom_llm_base_url: cfg.custom_llm_base_url,
+                    custom_llm_synthesis_model: cfg.custom_llm_synthesis_model,
+                    custom_llm_classifier_model: cfg.custom_llm_classifier_model,
+                    synthesis_model: cfg.custom_llm_synthesis_model,
+                    classifier_model: cfg.custom_llm_classifier_model,
+                  });
+                  setCustomConfig({
+                    base_url: cfg.custom_llm_base_url,
+                    synthesis_model: cfg.custom_llm_synthesis_model,
+                    classifier_model: cfg.custom_llm_classifier_model,
+                  });
+                }
+                setLlmSaveStatus("saved");
+                setTimeout(() => setLlmSaveStatus("idle"), 1800);
+              } catch (e: any) {
+                // eslint-disable-next-line no-console
+                console.error("[keepr] setSecret failed:", e);
+                setLlmSaveStatus("error");
+              }
+            };
+
+            if (activeProvider === "custom") {
+              return (
+                <>
+                  <Field label="Base URL">
+                    <input
+                      className={inputCls}
+                      value={cfg.custom_llm_base_url || ""}
+                      placeholder="http://localhost:11434"
+                      onChange={(e) => setCfg({ ...cfg, custom_llm_base_url: e.target.value })}
+                      onBlur={() => setConfig({ custom_llm_base_url: cfg.custom_llm_base_url })}
+                    />
+                  </Field>
+                  <Field label="API key (optional)">
+                    <div className="flex gap-2">
+                      <input
+                        type="password"
+                        className={inputCls}
+                        value={llmKey}
+                        placeholder="optional"
+                        onChange={(e) => {
+                          setLlmKey(e.target.value);
+                          if (llmSaveStatus !== "idle") setLlmSaveStatus("idle");
+                        }}
+                      />
+                      <Ghost onClick={saveKey}>
+                        {llmSaveStatus === "saved" ? "Saved" : llmSaveStatus === "error" ? "Failed" : "Save"}
+                      </Ghost>
+                    </div>
+                  </Field>
+                </>
+              );
+            }
+
             return (
               <Field label={`${p.label} API key`}>
                 <div className="flex gap-2">
@@ -133,37 +204,8 @@ export function Settings() {
                       if (llmSaveStatus !== "idle") setLlmSaveStatus("idle");
                     }}
                   />
-                  <Ghost
-                    onClick={async () => {
-                      try {
-                        await setSecret(
-                          SECRET_KEYS[activeProvider],
-                          llmKey.trim()
-                        );
-                        // Read-back verification — catches silent keychain
-                        // failures in unsigned dev builds.
-                        const readBack = await getSecret(
-                          SECRET_KEYS[activeProvider]
-                        );
-                        if (readBack !== llmKey.trim()) {
-                          throw new Error(
-                            "Key did not persist (keychain read-back mismatch)"
-                          );
-                        }
-                        setLlmSaveStatus("saved");
-                        setTimeout(() => setLlmSaveStatus("idle"), 1800);
-                      } catch (e: any) {
-                        // eslint-disable-next-line no-console
-                        console.error("[keepr] setSecret failed:", e);
-                        setLlmSaveStatus("error");
-                      }
-                    }}
-                  >
-                    {llmSaveStatus === "saved"
-                      ? "Saved"
-                      : llmSaveStatus === "error"
-                      ? "Failed"
-                      : "Save"}
+                  <Ghost onClick={saveKey}>
+                    {llmSaveStatus === "saved" ? "Saved" : llmSaveStatus === "error" ? "Failed" : "Save"}
                   </Ghost>
                   <Ghost onClick={() => openExternal(p.keyUrl)}>
                     Open dashboard
@@ -175,17 +217,43 @@ export function Settings() {
           <Field label="Synthesis model">
             <input
               className={inputCls}
-              value={cfg.synthesis_model}
-              onChange={(e) => setCfg({ ...cfg, synthesis_model: e.target.value })}
-              onBlur={() => setConfig({ synthesis_model: cfg.synthesis_model })}
+              value={cfg.llm_provider === "custom" ? (cfg.custom_llm_synthesis_model || "") : cfg.synthesis_model}
+              placeholder={cfg.llm_provider === "custom" ? "e.g. llama3.1:70b" : undefined}
+              onChange={(e) => {
+                if (cfg.llm_provider === "custom") {
+                  setCfg({ ...cfg, custom_llm_synthesis_model: e.target.value, synthesis_model: e.target.value });
+                } else {
+                  setCfg({ ...cfg, synthesis_model: e.target.value });
+                }
+              }}
+              onBlur={() => {
+                if (cfg.llm_provider === "custom") {
+                  setConfig({ custom_llm_synthesis_model: cfg.custom_llm_synthesis_model, synthesis_model: cfg.custom_llm_synthesis_model });
+                } else {
+                  setConfig({ synthesis_model: cfg.synthesis_model });
+                }
+              }}
             />
           </Field>
           <Field label="Classifier model">
             <input
               className={inputCls}
-              value={cfg.classifier_model}
-              onChange={(e) => setCfg({ ...cfg, classifier_model: e.target.value })}
-              onBlur={() => setConfig({ classifier_model: cfg.classifier_model })}
+              value={cfg.llm_provider === "custom" ? (cfg.custom_llm_classifier_model || "") : cfg.classifier_model}
+              placeholder={cfg.llm_provider === "custom" ? "e.g. llama3.1:8b" : undefined}
+              onChange={(e) => {
+                if (cfg.llm_provider === "custom") {
+                  setCfg({ ...cfg, custom_llm_classifier_model: e.target.value, classifier_model: e.target.value });
+                } else {
+                  setCfg({ ...cfg, classifier_model: e.target.value });
+                }
+              }}
+              onBlur={() => {
+                if (cfg.llm_provider === "custom") {
+                  setConfig({ custom_llm_classifier_model: cfg.custom_llm_classifier_model, classifier_model: cfg.custom_llm_classifier_model });
+                } else {
+                  setConfig({ classifier_model: cfg.classifier_model });
+                }
+              }}
             />
           </Field>
         </Panel>

--- a/src/services/llm.ts
+++ b/src/services/llm.ts
@@ -5,7 +5,7 @@
 import { fetch } from "@tauri-apps/plugin-http";
 import { SECRET_KEYS, getSecret } from "./secrets";
 
-export type LLMProviderId = "anthropic" | "openai" | "openrouter";
+export type LLMProviderId = "anthropic" | "openai" | "openrouter" | "custom";
 
 export interface LLMMessage {
   role: "system" | "user" | "assistant";
@@ -39,6 +39,23 @@ export interface LLMProvider {
   defaultClassifierModel: string;
   complete(opts: LLMCallOptions): Promise<LLMCallResult>;
   test(keyOverride?: string): Promise<boolean>;
+}
+
+/** Runtime config for the custom provider, loaded from app_config. */
+export interface CustomProviderConfig {
+  base_url: string;
+  synthesis_model: string;
+  classifier_model: string;
+}
+
+let _customConfig: CustomProviderConfig | null = null;
+
+export function setCustomConfig(cfg: CustomProviderConfig) {
+  _customConfig = cfg;
+}
+
+export function getCustomConfig(): CustomProviderConfig | null {
+  return _customConfig;
 }
 
 // ---- Anthropic -----------------------------------------------------------
@@ -213,10 +230,65 @@ const openrouter: LLMProvider = {
   },
 };
 
+// ---- Custom (OpenAI-compatible) -------------------------------------------
+
+const custom: LLMProvider = {
+  id: "custom",
+  label: "Custom",
+  keyUrl: "", // no dashboard — user provides their own
+  defaultSynthesisModel: "default",
+  defaultClassifierModel: "default",
+
+  async complete(opts) {
+    const cfg = _customConfig;
+    if (!cfg?.base_url) throw new Error("Custom provider not configured — set a base URL in Settings.");
+    const key = opts.keyOverride || (await getSecret(SECRET_KEYS.custom));
+    const url = cfg.base_url.replace(/\/+$/, "") + "/v1/chat/completions";
+    const msgs: LLMMessage[] = [];
+    if (opts.system) msgs.push({ role: "system", content: opts.system });
+    msgs.push(...opts.messages);
+    const headers: Record<string, string> = {
+      "content-type": "application/json",
+    };
+    if (key) headers["Authorization"] = `Bearer ${key}`;
+    const res = await fetch(url, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({
+        model: opts.model,
+        temperature: opts.temperature ?? 0.2,
+        max_tokens: opts.max_tokens ?? 4096,
+        messages: msgs,
+      }),
+    });
+    if (!res.ok) {
+      const t = await res.text().catch(() => "");
+      throw new Error(`Custom endpoint ${res.status}: ${t.slice(0, 300)}`);
+    }
+    const data: any = await res.json();
+    return {
+      text: data.choices?.[0]?.message?.content ?? "",
+      input_tokens: data.usage?.prompt_tokens ?? 0,
+      output_tokens: data.usage?.completion_tokens ?? 0,
+    };
+  },
+
+  async test(keyOverride?: string) {
+    await this.complete({
+      model: _customConfig?.classifier_model || "default",
+      messages: [{ role: "user", content: "Reply with just: ok" }],
+      max_tokens: 10,
+      keyOverride,
+    });
+    return true;
+  },
+};
+
 export const PROVIDERS: Record<LLMProviderId, LLMProvider> = {
   anthropic,
   openai,
   openrouter,
+  custom,
 };
 
 export function getProvider(id: LLMProviderId): LLMProvider {

--- a/src/services/pipeline.ts
+++ b/src/services/pipeline.ts
@@ -35,7 +35,7 @@ import {
 } from "./slack";
 import { fetchProjectActivity, type FetchedJiraIssue } from "./jira";
 import { fetchTeamActivity, type FetchedLinearIssue } from "./linear";
-import { getProvider } from "./llm";
+import { getProvider, setCustomConfig } from "./llm";
 import { writeMemory, readMemoryContext } from "./memory";
 
 // ---- Normalization -------------------------------------------------------
@@ -569,6 +569,13 @@ export async function runWorkflow(opts: RunOptions): Promise<RunResult> {
     }
 
     // ---- Map (Haiku per bucket) ----
+    if (cfg.llm_provider === "custom") {
+      setCustomConfig({
+        base_url: cfg.custom_llm_base_url,
+        synthesis_model: cfg.custom_llm_synthesis_model,
+        classifier_model: cfg.custom_llm_classifier_model,
+      });
+    }
     const provider = getProvider(cfg.llm_provider);
     progress("map", `Summarizing ${buckets.size} sources`);
 

--- a/src/services/secrets.ts
+++ b/src/services/secrets.ts
@@ -16,6 +16,7 @@ export const SECRET_KEYS = {
   anthropic: "llm.anthropic.key",
   openai: "llm.openai.key",
   openrouter: "llm.openrouter.key",
+  custom: "llm.custom.key",
   github: "github.token",
   slackBot: "slack.bot_token",
   slackClientId: "slack.client_id",


### PR DESCRIPTION
## Summary
- Adds a 4th LLM provider ("Custom") for any OpenAI-compatible endpoint — Ollama, vLLM, LM Studio, llama.cpp, text-generation-webui, etc.
- Users configure base URL, synthesis model, classifier model, and an optional API key
- Preserves the two-tier pipeline (classifier + synthesizer) and token usage tracking

## Changes
- **`src/services/llm.ts`** — `custom` provider using `/v1/chat/completions`, `CustomProviderConfig` type, `get/setCustomConfig()`
- **`src/lib/types.ts`** — `"custom"` added to `Provider`/`AppConfig.llm_provider`, three new config fields for base URL and model names
- **`src/services/secrets.ts`** — `custom` key entry
- **`src/components/onboarding/StepLLM.tsx`** — Custom provider card in onboarding with base URL, model names, and optional key fields
- **`src/screens/Settings.tsx`** — Custom provider in settings with base URL, optional key, and model name fields
- **`src/services/pipeline.ts`** — Loads custom config before pipeline runs

## Test plan
- [ ] Select "Custom" in onboarding, enter Ollama base URL (`http://localhost:11434`), model names, test & save
- [ ] Verify test call succeeds with a running Ollama instance
- [ ] Verify test call without API key works (local servers)
- [ ] Verify test call with API key works (authenticated endpoints)
- [ ] Switch between custom and other providers in Settings, confirm keys/URLs persist independently
- [ ] Run a workflow end-to-end with custom provider, verify both classifier and synthesizer calls succeed
- [ ] Verify token tracking reports correctly (or 0 if endpoint doesn't report usage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)