### PR TITLE
Fix provider grid overflow — switch to 2x2 layout

### DIFF
--- a/src/components/onboarding/StepLLM.tsx
+++ b/src/components/onboarding/StepLLM.tsx
@@ -155,7 +155,7 @@ export function StepLLM({ onNext }: { onNext: () => void }) {
         {" "}— Pro subscriptions don't include API access.
       </p>
 
-      <div className="mb-6 grid grid-cols-4 gap-2">
+      <div className="mb-6 grid grid-cols-2 gap-2">
         {PROVIDERS.map((row) => {
           const active = provider === row.id;
           return (


### PR DESCRIPTION
The 4-column grid was too tight for the "Recommended" badge on Anthropic, causing text overflow. A 2x2 grid gives each card enough room.