### PR TITLE
Add open-source community files and polish README

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,42 @@
+---
+name: Bug report
+about: Report a bug in Keepr
+title: "[BUG] "
+labels: ["bug"]
+assignees: ""
+---
+
+## Describe the bug
+
+A clear and concise description of what the bug is.
+
+## What you ran
+
+- **Workflow:** (e.g. team pulse, 1:1 prep, weekly update)
+- **Repos selected:** (e.g. acme/billing, acme/platform)
+- **Slack channels selected:** (e.g. #eng-general, #incidents)
+- **Approximate date range of data:** (e.g. last 7 days)
+
+## Expected behavior
+
+One sentence on what you expected to happen.
+
+## What happened instead
+
+Paste the relevant section of the generated markdown. Redact names if you need to. If the model made an unsupported claim, note the exact sentence and the evidence IDs (`ev_N`) it cited or failed to cite.
+
+## Screenshots
+
+If applicable, add screenshots of the UI issue.
+
+## Environment
+
+- **OS:** [e.g. macOS 15.2]
+- **Keepr version:** [e.g. 0.1.0]
+- **LLM provider:** [e.g. Anthropic, OpenAI, OpenRouter]
+
+## Additional context
+
+Add any other context about the problem here.
+
+**Note:** Bug reports without reproducible evidence get closed with a request for more detail. This is not gatekeeping -- it is that prompt quality issues are impossible to triage from vibes.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Discussions
+    url: https://github.com/keeprhq/keepr/discussions
+    about: "Ask usage questions and discuss features in Discussions"

--- a/.github/ISSUE_TEMPLATE/false_claim.md
+++ b/.github/ISSUE_TEMPLATE/false_claim.md
@@ -1,0 +1,31 @@
+---
+name: False claim
+about: Report a fabricated or unsupported claim in Keepr's output
+title: "[FALSE CLAIM] "
+labels: ["false-claim", "P0"]
+assignees: ""
+---
+
+## The false claim
+
+Paste the exact sentence from the generated output that is false or unsupported.
+
+## Why it's false
+
+Explain what the evidence actually says vs. what the model claimed. Include the `ev_N` IDs that should have prevented this claim, or note that no evidence supports it at all.
+
+## Workflow and context
+
+- **Workflow:** (e.g. team pulse, 1:1 prep)
+- **LLM provider:** (e.g. Anthropic, OpenAI)
+- **Approximate data volume:** (e.g. 5 channels, 3 repos, 7-day window)
+
+## Session file
+
+If possible, attach or paste the relevant sections of the session markdown file from your memory directory (`sessions/*.md`). Redact names if needed.
+
+## Additional context
+
+Anything else that might help reproduce the issue.
+
+**A single fabricated blocker or invented morale read is worse than fifty edits on otherwise factual output. These are always P0.**

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,31 @@
+---
+name: Feature request
+about: Suggest an improvement or new feature for Keepr
+title: "[FEATURE] "
+labels: ["enhancement"]
+assignees: ""
+---
+
+## Is your feature request related to a problem?
+
+A clear description of the problem. Ex. "When I run 1:1 prep, I always have to..."
+
+## How do you solve this today?
+
+What's your current workaround? Even if it's "I don't, I just skip it."
+
+## Describe the solution you'd like
+
+A clear description of what you want to happen. Include what the output would look like if it's a workflow or prompt change.
+
+## Describe alternatives you've considered
+
+Any other approaches you've thought about and why they might or might not work.
+
+## How would you test this on real data?
+
+Describe a real scenario where this feature would have changed your workflow. Features that only make sense for hypothetical users are unlikely to be prioritized.
+
+## Additional context
+
+Add any other context, screenshots, or examples here. Link to the relevant section of [`ROADMAP.md`](../../ROADMAP.md) if it relates to a planned item.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,41 @@
+version: 2
+updates:
+  # npm dependencies
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "04:00"
+    commit-message:
+      prefix: "deps"
+      prefix-development: "deps-dev"
+      include: "scope"
+    open-pull-requests-limit: 5
+    target-branch: "main"
+
+  # Rust/Cargo dependencies
+  - package-ecosystem: "cargo"
+    directory: "/src-tauri"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "04:00"
+    commit-message:
+      prefix: "deps"
+      include: "scope"
+    open-pull-requests-limit: 5
+    target-branch: "main"
+
+  # GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/.github/workflows"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "04:00"
+    commit-message:
+      prefix: "ci"
+      include: "scope"
+    open-pull-requests-limit: 3
+    target-branch: "main"

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,41 @@
+## Description
+
+<!-- What problem does this solve? Be specific about the user problem, not just the code change. -->
+
+## Type of Change
+
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Prompt change (tuning or rewriting a prompt template)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] Documentation update
+- [ ] Refactoring (no functional changes)
+
+## Related Issues
+
+Fixes #
+
+## How you tested on real data
+
+<!-- Keepr is built dogfood-first. Describe which workflow you ran, on what data, and what the output looked like. "I ran the tests" is not sufficient for prompt or pipeline changes. -->
+
+## What you checked did not change
+
+<!-- For prompt changes: paste a before/after diff of at least one session output. For pipeline changes: confirm which workflows you re-ran. -->
+
+## Checklist
+
+- [ ] I have used Keepr on real data for at least one session
+- [ ] `npx tsc --noEmit` passes
+- [ ] `npx vite build` succeeds
+- [ ] `cargo check --locked` in `src-tauri/` succeeds
+- [ ] No new dependencies without justification below
+- [ ] I have updated documentation if applicable
+
+## New dependencies (if any)
+
+<!-- Justify each new dependency. The dependency graph is small on purpose. -->
+
+## Screenshots (if applicable)
+
+<!-- UI changes: include before and after screenshots. -->

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,36 @@
+# Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment:
+
+* Being respectful of differing opinions and experiences
+* Giving and gracefully accepting constructive feedback
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior:
+
+* The use of sexualized language or imagery, and unwelcome sexual attention
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information without explicit permission
+* Other conduct which could reasonably be considered inappropriate
+
+## Scope
+
+This Code of Conduct applies within all community spaces, including issues, pull requests, discussions, and any other channel managed by the project.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the project maintainers at **keeprhq** on GitHub. All complaints will be reviewed and investigated promptly and fairly.
+
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, issues, and other contributions that are not aligned to this Code of Conduct.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org/), version 2.0.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,7 @@
 # Contributing
 
+Thank you for your interest in contributing to Keepr. Please review our [Code of Conduct](./CODE_OF_CONDUCT.md) before participating.
+
 Keepr is built dogfood-first. That shapes how contributions work.
 
 ## The rule that matters most
@@ -80,3 +82,11 @@ Bug reports without reproducible evidence get closed with a request for more det
 - Telemetry in v1 (planned for v1.5, opt-in, aggregate only)
 - Features that only make sense for a hypothetical future user
 - Dependencies with a single maintainer and no release in the last 12 months, absent a specific reason
+
+## Security vulnerabilities
+
+If you find a security issue, do not open a public issue. See [`SECURITY.md`](./SECURITY.md) for how to report it.
+
+## License
+
+By contributing to Keepr, you agree that your contributions will be licensed under the MIT License.

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,0 +1,11 @@
+# Contributors
+
+## Project Maintainers
+
+- [Manikandan](https://github.com/mvmcode) - Creator
+
+## How to Get Listed
+
+Ship a merged pull request and you'll be added here. We value every contribution -- code, docs, prompt tuning, bug reports with reproduction steps, and design feedback.
+
+See [`CONTRIBUTING.md`](./CONTRIBUTING.md) for how to get started.

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,8 +1,12 @@
 # Contributors
 
-## Project Maintainers
+## Creator & Maintainer
 
-- [Manikandan](https://github.com/mvmcode) - Creator
+- [Raghavan VM](https://github.com/raghavanvm)
+
+## Maintainers
+
+- [Manikandan](https://github.com/mvmcode)
 
 ## How to Get Listed
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 <founder>
+Copyright (c) 2026 Keepr Contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -2,87 +2,136 @@
   <img src="public/icon-192x192.png" width="80" alt="Keepr icon" />
 </p>
 
-# Keepr
+<h1 align="center">Keepr</h1>
 
-Keepr is an AI memory layer for your team that stays local to your machine. It runs locally on your laptop/machine — your data never touches a middleman server.
+<p align="center">
+  <strong>AI memory layer for engineering managers. Local-first. No backend. No account.</strong>
+</p>
 
-Point it at your Slack workspace and a handful of GitHub repos, pick an LLM provider, and Keepr turns the week's exhaust into a cited team pulse or 1:1 prep in about a minute. It's a desktop app, not a SaaS. No backend, no account, no analytics.
+<p align="center">
+  <a href="https://github.com/keeprhq/keepr/blob/main/LICENSE"><img src="https://img.shields.io/badge/License-MIT-blue.svg" alt="License: MIT" /></a>
+  <a href="https://github.com/keeprhq/keepr/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/keeprhq/keepr/ci.yml?branch=main&label=CI" alt="Build Status" /></a>
+  <a href="https://github.com/keeprhq/keepr/releases"><img src="https://img.shields.io/github/v/release/keeprhq/keepr?label=release" alt="Release" /></a>
+</p>
+
+---
+
+Keepr is a desktop app that turns your team's Slack and GitHub exhaust into cited weekly briefs and 1:1 prep. It runs on your laptop -- your data never touches a middleman server.
+
+Point it at your Slack workspace and a handful of GitHub repos, pick an LLM provider, and Keepr produces an evidence-backed team pulse or 1:1 prep in about a minute. It is a desktop app, not a SaaS. No backend, no account, no analytics.
 
 ## Screenshots
 
 The app ships with a Granola-inspired monochromatic light theme. Inter for UI, Newsreader for display headings, JetBrains Mono for code.
 
-- `docs/screenshots/home.png` — command palette and session list
-- `docs/screenshots/team-pulse.png` — team pulse output with inline citations
-- `docs/screenshots/one-on-one.png` — 1:1 prep with memory context
-- `docs/screenshots/onboarding.png` — first-run credential setup
+<!-- Screenshots live in docs/screenshots/. Replace these placeholders before the public invite. -->
+<!-- ![Home](docs/screenshots/home.png) -->
+<!-- ![Team Pulse](docs/screenshots/team-pulse.png) -->
+<!-- ![1:1 Prep](docs/screenshots/one-on-one.png) -->
+<!-- ![Onboarding](docs/screenshots/onboarding.png) -->
 
-Screenshots live in `docs/screenshots/`. The placeholders will be replaced before the public invite.
+See [`docs/screenshots/`](docs/screenshots/) for the reference list and capture guidelines.
+
+## Features
+
+- **Team pulse** -- Monday-morning read of what happened across your team last week, evidence-backed and cited
+- **1:1 prep** -- Context for an upcoming 1:1 with recent work, open threads, and follow-up items
+- **Weekly engineering update** -- Stakeholder-ready summary: shipped, in progress, blocked, upcoming
+- **Performance evaluation** -- Evidence-organized eval with optional rubric mapping (scaffold, needs real-data tuning)
+- **Promo readiness** -- Gap analysis against target level with cited evidence
+- **Local memory** -- Observed facts persisted as plain markdown files you can open in Obsidian, grep, or commit to a private repo
+- **Keyboard-first UI** -- Command palette (Cmd+K), citation scroll, session history
+- **Zero telemetry** -- Nothing phones home. The founder cannot see your sessions.
+
+## Tech Stack
+
+| Layer | Technology |
+|-------|-----------|
+| Desktop shell | [Tauri 2](https://v2.tauri.app/) (Rust) |
+| Frontend | React 19, TypeScript, Tailwind CSS |
+| Database | SQLite via `tauri-plugin-sql` |
+| Secrets | macOS Keychain via `keyring` crate |
+| LLM providers | Anthropic, OpenAI, OpenRouter, or any OpenAI-compatible endpoint |
+| Data sources | Slack Web API, GitHub REST API, Jira Cloud, Linear GraphQL |
+| Build | Vite, Cargo |
 
 ## Quickstart
 
-You need Node 20+, Rust (stable), and npm.
+You need **Node 20+**, **Rust (stable)**, and **npm**.
 
 ```bash
+git clone https://github.com/keeprhq/keepr.git
+cd keepr
 npm install
 npx tauri dev
 ```
 
 That launches the Tauri window with Vite HMR. First run walks you through:
 
-1. Pick an LLM provider (Anthropic, OpenAI, or OpenRouter) and paste an API key
+1. Pick an LLM provider (Anthropic, OpenAI, OpenRouter, or custom) and paste an API key
 2. Create a Slack app from the provided manifest and paste its bot token
 3. Connect GitHub (PAT is fastest; device flow works once you register an OAuth app)
-4. Add team members (display name → GitHub handle → Slack user id)
-5. Pick a memory directory (defaults to `~/Documents/Keepr`)
-6. Read and acknowledge the privacy posture
+4. Optionally connect Jira and/or Linear
+5. Add team members (display name, GitHub handle, Slack user ID)
+6. Pick a memory directory (defaults to `~/Documents/Keepr`)
+7. Read and acknowledge the privacy posture
 
-Then press ⌘K and run `team pulse`, or type a team member's name for 1:1 prep.
+Then press Cmd+K and run `team pulse`, or type a team member's name for 1:1 prep.
 
-To produce a standalone debug binary:
+### Building a standalone binary
 
 ```bash
 npx tauri build --debug --no-bundle
 ./src-tauri/target/debug/keepr
 ```
 
-## Architecture at a glance
+## Architecture at a Glance
 
 ```
-fetch  →  prune  →  Haiku map  →  Sonnet reduce  →  write memory
+fetch  ->  prune  ->  Haiku map  ->  Sonnet reduce  ->  write memory
 ```
 
-- **`src-tauri/`** — thin Rust shell. SQLite bridge (`tauri-plugin-sql`), OS keychain bridge (`secrets.rs`), atomic file I/O with lock (`fs_atomic.rs`). No OAuth callback server, no background workers.
-- **`src/services/`** — TypeScript business logic. DB, secrets, GitHub, Slack, LLM providers, the map/reduce pipeline, and the memory layer.
-- **`src/prompts/`** — team pulse, 1:1 prep, and Haiku channel-summary prompts as plain markdown files, imported via `?raw`. Tune them by editing the file and reloading.
-- **`src/components/` and `src/screens/`** — React 19 UI. Command-palette-first navigation, keyboard shortcuts, bidirectional citation scrolling.
-- **`~/Documents/Keepr/`** (or wherever you pointed it) — canonical memory. Plain markdown files you can open in Obsidian, grep, or commit to a private repo. Keepr's own SQLite is metadata only; the memory itself is files on disk.
+- **`src-tauri/`** -- Thin Rust shell. SQLite bridge, OS keychain bridge (`secrets.rs`), atomic file I/O with lock (`fs_atomic.rs`). No OAuth callback server, no background workers.
+- **`src/services/`** -- TypeScript business logic. DB, secrets, GitHub, Slack, Jira, Linear, LLM providers, the map/reduce pipeline, and the memory layer.
+- **`src/prompts/`** -- Prompt templates as plain markdown files, imported via `?raw`. Tune them by editing the file and reloading.
+- **`src/components/` and `src/screens/`** -- React 19 UI. Command-palette-first navigation, keyboard shortcuts, bidirectional citation scrolling.
+- **`~/Documents/Keepr/`** (or wherever you pointed it) -- Canonical memory. Plain markdown files you can open in Obsidian, grep, or commit to a private repo. Keepr's SQLite is metadata only; the memory itself is files on disk.
 
-Evidence items get stable `ev_N` ids. The LLM cites by id only; the app resolves ids to URLs at render time. Memory files persist observed facts only — interpretations live in the session file for that run and never get appended to memory.
+Evidence items get stable `ev_N` IDs. The LLM cites by ID only; the app resolves IDs to URLs at render time. Memory files persist observed facts only -- interpretations live in the session file for that run and never get appended to memory.
 
-See `DESIGN.md` for the full design and `CHANGES.md` for deviations from it.
-
-## Privacy posture
+## Privacy Posture
 
 The honest version:
 
 - **Keepr operates no servers.** There is no backend, no analytics, no telemetry. The founder cannot see your sessions.
 - **Your data still leaves your laptop in two specific ways:**
-  1. To Slack and GitHub — the original sources. You already trust them with this data.
+  1. To Slack and GitHub (and optionally Jira/Linear) -- the original sources. You already trust them with this data.
   2. To whichever LLM provider you configured. Raw Slack message content and PR descriptions flow into their API for synthesis. This is the main remaining trust surface.
-- **What local-first actually buys you:** no middleman vendor holds your data. The number of parties who see your content is two (Slack/GitHub plus your LLM provider) instead of three. Your team's data is never pooled with other customers'.
+- **What local-first buys you:** no middleman vendor holds your data. The number of parties who see your content is two instead of three. Your team's data is never pooled with other customers'.
 - **What it does not buy you:** it does not eliminate the LLM provider from your trust model. If your company forbids sending Slack messages to Anthropic or OpenAI, Keepr cannot help you in v1.
 
-The full version lives in [`PRIVACY.md`](./PRIVACY.md). Read it before you connect a real work Slack.
+Read the full version in [`PRIVACY.md`](./PRIVACY.md) before you connect a real work Slack.
 
 ## Roadmap
 
-v1 is team pulse plus 1:1 prep on macOS. v1.5 brings weekly engineering updates, Windows and Linux, and auto-update. v2 is the rubric-aware performance and promo work. See [`ROADMAP.md`](./ROADMAP.md) for the full picture — v2 features are planned, not promised.
+v1 is team pulse plus 1:1 prep on macOS. v1.5 brings weekly engineering updates, Windows and Linux, and auto-update. v2 is the rubric-aware performance and promo work. See [`ROADMAP.md`](./ROADMAP.md) for the full picture -- v2 features are planned, not promised.
 
 ## Contributing
 
 This is a dogfood-first project. Before opening a PR, read [`CONTRIBUTING.md`](./CONTRIBUTING.md). The short version: use the app on real data for at least one session before proposing changes to prompts or pipeline behavior.
 
+Please also review our [`CODE_OF_CONDUCT.md`](./CODE_OF_CONDUCT.md).
+
+## Security
+
+If you discover a security vulnerability, please report it responsibly. See [`SECURITY.md`](./SECURITY.md) for the process and what's in scope.
+
 ## License
 
 MIT. See [`LICENSE`](./LICENSE).
+
+---
+
+<p align="center">
+  Built with Tauri, React, and TypeScript
+</p>

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,57 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported          |
+| ------- | ------------------ |
+| latest  | :white_check_mark: |
+| < 0.1   | :x:                |
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in Keepr, please report it responsibly. **Do not open a public GitHub issue.**
+
+Email the maintainer directly or use [GitHub's private vulnerability reporting](https://github.com/keeprhq/keepr/security/advisories/new).
+
+When reporting, please include:
+
+- Description of the vulnerability
+- Steps to reproduce the issue
+- Potential impact (what data could be exposed, what could be exploited)
+- Suggested fix, if any
+
+We will acknowledge your report within 48 hours and provide a detailed response within 7 days.
+
+## Security Model
+
+Keepr is a local-first desktop application. Its security posture is different from a SaaS product:
+
+- **No Keepr-operated servers.** There is no backend to breach.
+- **Secrets in OS keychain.** API keys and tokens are stored in macOS Keychain, not in config files or SQLite.
+- **Data leaves your machine in two ways only:** to Slack/GitHub (the original sources) and to the LLM provider you configured. See [`PRIVACY.md`](./PRIVACY.md) for the full picture.
+- **No telemetry in v1.** Nothing phones home.
+
+### What we consider in scope
+
+- Secrets leaking to disk outside the OS keychain
+- SQLite data accessible to other apps without OS-level protection
+- Prompt injection that causes the LLM to exfiltrate data from the evidence payload
+- Memory file writes that could overwrite or read files outside the memory directory
+- Dependencies with known CVEs
+
+### What we consider out of scope
+
+- Attacks requiring physical access to an unlocked machine (that's an OS-level concern)
+- LLM provider data handling policies (you chose your provider; read their policy)
+- Slack/GitHub API security (those are upstream concerns)
+
+## Disclosure Policy
+
+When we receive a security report, we will:
+
+1. Confirm the problem and determine affected versions
+2. Audit related code for similar issues
+3. Prepare a fix and release it promptly
+4. Credit the reporter in the release notes (unless they prefer anonymity)
+
+Thank you for helping keep Keepr and its users safe.


### PR DESCRIPTION
## Summary

- Add standard open-source community files modeled after SageMCP's setup, adapted to Keepr's identity and tech stack
- Add **CODE_OF_CONDUCT.md** (Contributor Covenant v2.0)
- Add **SECURITY.md** with Keepr-specific security model (local-first scope, keychain secrets, no backend)
- Add **CONTRIBUTORS.md** with maintainer list
- Add **GitHub issue templates**: bug report (with Keepr-specific fields like workflow, evidence IDs), feature request (with "how would you test on real data" prompt), false claim (P0 — Keepr's most important issue type)
- Add **PR template** with dogfood-first checklist (real data testing, before/after diffs for prompt changes)
- Add **dependabot.yml** for npm, cargo, and GitHub Actions dependency updates
- Polish **README.md** with centered header, shield badges (license, CI, release), features list, tech stack table, clone instructions, and links to all community docs
- Fix **LICENSE** copyright holder (was `<founder>`, now `Keepr Contributors`)
- Add Code of Conduct reference and license section to **CONTRIBUTING.md**

## Test plan

- [ ] Verify all links in README resolve (badges will work once repo is public on keeprhq org)
- [ ] Confirm issue templates appear in GitHub's "New Issue" picker
- [ ] Confirm PR template auto-populates on new PRs
- [ ] Verify dependabot creates its first PRs next Monday

🤖 Generated with [Claude Code](https://claude.com/claude-code)