### PR TITLE
Update tagline to 'AI memory layer for engineering leaders'

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # Keepr
 
-On-device AI Chief of Staff for engineering managers. Tauri v2 desktop app (React + Rust).
+On-device AI memory layer for engineering leaders. Tauri v2 desktop app (React + Rust).
 
 ## Skill routing
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 </p>
 
 <p align="center">
-  <strong>AI memory layer for engineering managers. Local-first. No backend. No account.</strong>
+  <strong>AI memory layer for engineering leaders. Local-first. No backend. No account.</strong>
 </p>
 
 <p align="center">

--- a/docs/index.html
+++ b/docs/index.html
@@ -3,10 +3,10 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Keepr -- AI Chief of Staff for Engineering Managers</title>
+  <title>Keepr -- AI memory layer for engineering leaders</title>
   <meta name="description" content="Keepr turns Slack and GitHub exhaust into weekly team pulses and 1:1 prep. On-device, privacy-first, open source." />
   <meta property="og:title" content="Keepr" />
-  <meta property="og:description" content="AI Chief of Staff for engineering managers. On-device, privacy-first, open source." />
+  <meta property="og:description" content="AI memory layer for engineering leaders. On-device, privacy-first, open source." />
   <meta property="og:type" content="website" />
   <meta property="og:url" content="https://keeprhq.github.io/keepr/" />
   <link rel="icon" href="favicon.ico" type="image/x-icon" />
@@ -353,7 +353,7 @@
     </header>
 
     <section class="hero">
-      <h1>AI Chief of Staff for engineering managers</h1>
+      <h1>AI memory layer for engineering leaders</h1>
       <p>
         Keepr turns your team's Slack and GitHub exhaust into weekly
         team pulses and 1:1 prep. It runs on your laptop. Your data

--- a/landing/index.html
+++ b/landing/index.html
@@ -5,12 +5,12 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
     <meta property="og:image" content="/og-image-1200x630.png" />
-    <meta property="og:title" content="Keepr — an AI chief of staff for engineering managers" />
+    <meta property="og:title" content="Keepr — an AI memory layer for engineering leaders" />
     <meta property="og:description" content="Keepr runs locally on your laptop — your Slack data never touches a middleman server." />
-    <title>Keepr — an AI chief of staff for engineering managers</title>
+    <title>Keepr — an AI memory layer for engineering leaders</title>
     <meta
       name="description"
-      content="Keepr is an AI chief of staff for engineering managers. It runs locally on your laptop — your Slack data never touches a middleman server."
+      content="Keepr is an AI memory layer for engineering leaders. It runs locally on your laptop — your Slack data never touches a middleman server."
     />
     <link rel="preconnect" href="https://rsms.me/" />
     <link rel="stylesheet" href="https://rsms.me/inter/inter.css" />
@@ -223,7 +223,7 @@
     </header>
 
     <main>
-      <h1>An AI chief of staff for engineering managers.</h1>
+      <h1>An AI memory layer for engineering leaders.</h1>
       <p class="lede">
         Keepr runs on your laptop and turns a week of Slack and GitHub exhaust
         into a cited team pulse or 1:1 prep in about a minute.

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -39,7 +39,7 @@
       "icons/icon.ico"
     ],
     "category": "Productivity",
-    "shortDescription": "AI Chief of Staff for engineering managers",
+    "shortDescription": "AI memory layer for engineering leaders",
     "longDescription": "Keepr turns Slack and GitHub exhaust into weekly team pulses and 1:1 prep, on-device."
   }
 }

--- a/src/components/onboarding/StepSlack.tsx
+++ b/src/components/onboarding/StepSlack.tsx
@@ -23,7 +23,7 @@ import * as slack from "../../services/slack";
 
 export const MANIFEST_YAML = `display_information:
   name: Keepr (internal)
-  description: Local AI Chief of Staff reading public channels for team pulse
+  description: Local AI memory layer reading public channels for team pulse
   background_color: "#0a0a0a"
 features:
   bot_user:


### PR DESCRIPTION
Replace 'AI Chief of Staff for engineering managers' with 'AI memory layer for engineering leaders' across all user-facing surfaces: README, landing page, Tauri config, onboarding, OG tags. LLM system prompts kept as-is (internal persona, not user-facing).

## Description

<!-- What problem does this solve? Be specific about the user problem, not just the code change. -->

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Prompt change (tuning or rewriting a prompt template)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

Fixes #

## How you tested on real data

<!-- Keepr is built dogfood-first. Describe which workflow you ran, on what data, and what the output looked like. "I ran the tests" is not sufficient for prompt or pipeline changes. -->

## What you checked did not change

<!-- For prompt changes: paste a before/after diff of at least one session output. For pipeline changes: confirm which workflows you re-ran. -->

## Checklist

- [ ] I have used Keepr on real data for at least one session
- [ ] `npx tsc --noEmit` passes
- [ ] `npx vite build` succeeds
- [ ] `cargo check --locked` in `src-tauri/` succeeds
- [ ] No new dependencies without justification below
- [ ] I have updated documentation if applicable

## New dependencies (if any)

<!-- Justify each new dependency. The dependency graph is small on purpose. -->

## Screenshots (if applicable)

<!-- UI changes: include before and after screenshots. -->
