### PR TITLE
Fix Jira and Linear integrations; add file logging

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@tauri-apps/plugin-dialog": "^2.0.1",
         "@tauri-apps/plugin-fs": "^2.0.3",
         "@tauri-apps/plugin-http": "^2.0.1",
+        "@tauri-apps/plugin-log": "^2.8.0",
         "@tauri-apps/plugin-opener": "^2.2.2",
         "@tauri-apps/plugin-shell": "^2.0.1",
         "@tauri-apps/plugin-sql": "^2.0.1",
@@ -920,6 +921,15 @@
       "license": "MIT OR Apache-2.0",
       "dependencies": {
         "@tauri-apps/api": "^2.10.1"
+      }
+    },
+    "node_modules/@tauri-apps/plugin-log": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-log/-/plugin-log-2.8.0.tgz",
+      "integrity": "sha512-a+7rOq3MJwpTOLLKbL8d0qGZ85hgHw5pNOWusA9o3cf7cEgtYHiGY/+O8fj8MvywQIGqFv0da2bYQDlrqLE7rw==",
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@tauri-apps/api": "^2.8.0"
       }
     },
     "node_modules/@tauri-apps/plugin-opener": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@tauri-apps/plugin-dialog": "^2.0.1",
     "@tauri-apps/plugin-fs": "^2.0.3",
     "@tauri-apps/plugin-http": "^2.0.1",
+    "@tauri-apps/plugin-log": "^2.8.0",
     "@tauri-apps/plugin-opener": "^2.2.2",
     "@tauri-apps/plugin-shell": "^2.0.1",
     "@tauri-apps/plugin-sql": "^2.0.1",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -50,6 +50,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "android_log-sys"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84521a3cf562bc62942e294181d9eef17eb38ceb8c68677bc49f144e4c3d4f8d"
+
+[[package]]
+name = "android_logger"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbb4e440d04be07da1f1bf44fb4495ebd58669372fe0cffa6e48595ac5bd88a3"
+dependencies = [
+ "android_log-sys",
+ "env_filter",
+ "log",
+]
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -395,6 +412,18 @@ name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
+name = "byte-unit"
+version = "5.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c6d47a4e2961fb8721bcfc54feae6455f2f64e7054f9bc67e875f0e77f4c58d"
+dependencies = [
+ "rust_decimal",
+ "schemars 1.2.1",
+ "serde",
+ "utf8-width",
+]
 
 [[package]]
 name = "bytecheck"
@@ -1137,6 +1166,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_filter"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bf3c259d255ca70051b30e2e95b5446cdb8949ac4cd22c0d7fd634d89f568e2"
+dependencies = [
+ "log",
+ "regex",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1208,6 +1247,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
 dependencies = [
  "simd-adler32",
+]
+
+[[package]]
+name = "fern"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4316185f709b23713e41e3195f90edef7fb00c3ed4adc79769cf09cc762a3b29"
+dependencies = [
+ "log",
 ]
 
 [[package]]
@@ -2299,6 +2347,7 @@ dependencies = [
  "chrono",
  "hex",
  "keyring",
+ "log",
  "serde",
  "serde_json",
  "sha2 0.11.0",
@@ -2307,6 +2356,7 @@ dependencies = [
  "tauri-plugin-dialog",
  "tauri-plugin-fs",
  "tauri-plugin-http",
+ "tauri-plugin-log",
  "tauri-plugin-opener",
  "tauri-plugin-shell",
  "tauri-plugin-sql",
@@ -2462,6 +2512,9 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+dependencies = [
+ "value-bag",
+]
 
 [[package]]
 name = "lru-slab"
@@ -2704,6 +2757,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "num_threads"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -5048,6 +5110,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-log"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7545bd67f070a4500432c826e2e0682146a1d6712aee22a2786490156b574d93"
+dependencies = [
+ "android_logger",
+ "byte-unit",
+ "fern",
+ "log",
+ "objc2",
+ "objc2-foundation",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "swift-rs",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
+ "time",
+]
+
+[[package]]
 name = "tauri-plugin-opener"
 version = "2.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5309,7 +5393,9 @@ checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
  "itoa",
+ "libc",
  "num-conv",
+ "num_threads",
  "powerfmt",
  "serde_core",
  "time-core",
@@ -5768,6 +5854,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
+name = "utf8-width"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1292c0d970b54115d14f2492fe0170adf21d68a1de108eebc51c1df4f346a091"
+
+[[package]]
 name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5784,6 +5876,12 @@ dependencies = [
  "serde_core",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "value-bag"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ba6f5989077681266825251a52748b8c1d8a4ad098cc37e440103d0ea717fc0"
 
 [[package]]
 name = "vcpkg"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -21,6 +21,8 @@ tauri-plugin-fs = "2"
 tauri-plugin-http = "2"
 tauri-plugin-opener = "2"
 tauri-plugin-store = "2"
+tauri-plugin-log = "2"
+log = "0.4"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 keyring = "3"

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -53,6 +53,7 @@
     "sql:allow-execute",
     "sql:allow-select",
     "sql:allow-load",
-    "store:default"
+    "store:default",
+    "log:default"
   ]
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -224,6 +224,20 @@ pub fn run() {
                 .add_migrations("sqlite:keepr.db", migrations())
                 .build(),
         )
+        .plugin(
+            tauri_plugin_log::Builder::new()
+                .level(log::LevelFilter::Info)
+                .targets([
+                    tauri_plugin_log::Target::new(tauri_plugin_log::TargetKind::LogDir {
+                        file_name: Some("keepr".into()),
+                    }),
+                    tauri_plugin_log::Target::new(tauri_plugin_log::TargetKind::Stdout),
+                    tauri_plugin_log::Target::new(tauri_plugin_log::TargetKind::Webview),
+                ])
+                .rotation_strategy(tauri_plugin_log::RotationStrategy::KeepOne)
+                .max_file_size(10 * 1024 * 1024)
+                .build(),
+        )
         .invoke_handler(tauri::generate_handler![
             secrets::secret_set,
             secrets::secret_get,

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,8 +1,14 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
 import { openUrl } from "@tauri-apps/plugin-opener";
+import { attachConsole } from "@tauri-apps/plugin-log";
 import App from "./App";
 import "./styles/globals.css";
+
+// Forward every WebView console.log / warn / error into the Rust log sink
+// (file at ~/Library/Logs/app.keepr.desktop/keepr.log + stdout). Fire-and-
+// forget: boot shouldn't block on logger attachment.
+attachConsole().catch(() => {});
 
 // Tauri's webview doesn't handle target="_blank" or external href clicks.
 // Intercept all clicks on <a> tags with an http(s) href and open them

--- a/src/services/jira.ts
+++ b/src/services/jira.ts
@@ -31,7 +31,30 @@ async function jira<T>(path: string, signal?: AbortSignal): Promise<T> {
   const headers = await jiraHeaders();
   const res = await fetch(`${base}${path}`, { headers, signal });
   if (!res.ok) {
-    throw new Error(`Jira ${path}: ${res.status} ${res.statusText}`);
+    const errText = await res.text().catch(() => "");
+    throw new Error(
+      `Jira ${path}: ${res.status} ${res.statusText}` +
+        (errText ? ` — ${errText.slice(0, 300)}` : "")
+    );
+  }
+  return (await res.json()) as T;
+}
+
+async function jiraPost<T>(path: string, body: unknown, signal?: AbortSignal): Promise<T> {
+  const base = await jiraBaseUrl();
+  const headers = await jiraHeaders();
+  const res = await fetch(`${base}${path}`, {
+    method: "POST",
+    headers,
+    body: JSON.stringify(body),
+    signal,
+  });
+  if (!res.ok) {
+    const errText = await res.text().catch(() => "");
+    throw new Error(
+      `Jira ${path}: ${res.status} ${res.statusText}` +
+        (errText ? ` — ${errText.slice(0, 300)}` : "")
+    );
   }
   return (await res.json()) as T;
 }
@@ -120,13 +143,16 @@ export async function fetchProjectActivity(
   const cursor = opts.forceRefresh ? null : await getFetchCursor("jira", cacheKey);
   const effectiveSince = cursor && cursor > sinceIso ? cursor : sinceIso;
 
-  // JQL: issues in the project updated since the effective time
+  // Legacy /rest/api/3/search was removed by Atlassian in May 2025 (returns
+  // 410 Gone). We now use the enhanced /rest/api/3/search/jql endpoint: POST
+  // with JSON body, cursor-based pagination via nextPageToken. The enhanced
+  // endpoint does NOT return the `comment` field — comments must be fetched
+  // per issue via /rest/api/3/issue/{key}/comment.
+  // https://developer.atlassian.com/cloud/jira/platform/changelog/
   const sinceDate = effectiveSince.split("T")[0];
-  const jql = encodeURIComponent(
-    `project = "${projectKey}" AND updated >= "${sinceDate}" ORDER BY updated DESC`
-  );
+  const jql = `project = "${projectKey}" AND updated >= "${sinceDate}" ORDER BY updated DESC`;
 
-  const data = await jira<{
+  const data = await jiraPost<{
     issues: Array<{
       id: string;
       key: string;
@@ -139,16 +165,17 @@ export async function fetchProjectActivity(
         reporter: { displayName: string; accountId: string } | null;
         created: string;
         updated: string;
-        comment?: { comments: Array<{
-          id: string;
-          author: { displayName: string; accountId: string };
-          body: any;
-          created: string;
-        }> };
       };
     }>;
+    nextPageToken?: string;
+    isLast?: boolean;
   }>(
-    `/rest/api/3/search?jql=${jql}&maxResults=100&fields=summary,description,status,assignee,reporter,created,updated,comment`,
+    "/rest/api/3/search/jql",
+    {
+      jql,
+      fields: ["summary", "description", "status", "assignee", "reporter", "created", "updated"],
+      maxResults: 100,
+    },
     opts.signal
   );
 
@@ -161,17 +188,32 @@ export async function fetchProjectActivity(
     const descText = extractJiraText(issue.fields.description);
     const issueUrl = `${base}/browse/${issue.key}`;
 
+    // Comments: separate call per issue (new endpoint doesn't inline them).
+    // Best-effort — if it fails, we keep the issue without comments.
     const comments: FetchedJiraComment[] = [];
-    for (const c of issue.fields.comment?.comments || []) {
-      const bodyText = extractJiraText(c.body);
-      if (!bodyText.trim()) continue;
-      comments.push({
-        source_id: `${issue.key}:comment/${c.id}`,
-        url: `${issueUrl}?focusedId=${c.id}`,
-        author: c.author?.displayName ?? null,
-        body: bodyText.slice(0, 800),
-        created: c.created,
-      });
+    try {
+      const commentData = await jira<{
+        comments: Array<{
+          id: string;
+          author: { displayName: string; accountId: string };
+          body: any;
+          created: string;
+        }>;
+      }>(`/rest/api/3/issue/${issue.key}/comment?maxResults=50`, opts.signal);
+
+      for (const c of commentData.comments || []) {
+        const bodyText = extractJiraText(c.body);
+        if (!bodyText.trim()) continue;
+        comments.push({
+          source_id: `${issue.key}:comment/${c.id}`,
+          url: `${issueUrl}?focusedId=${c.id}`,
+          author: c.author?.displayName ?? null,
+          body: bodyText.slice(0, 800),
+          created: c.created,
+        });
+      }
+    } catch {
+      // swallow — comments are auxiliary, shouldn't fail the whole fetch
     }
 
     out.push({

--- a/src/services/linear.ts
+++ b/src/services/linear.ts
@@ -27,12 +27,19 @@ async function linearFetch<T>(
   });
 
   if (!res.ok) {
-    throw new Error(`Linear API: ${res.status} ${res.statusText}`);
+    // Capture response body — GraphQL validation errors surface here as 400s
+    // and without the body we only see "400 Bad Request" which is useless.
+    const errText = await res.text().catch(() => "");
+    throw new Error(
+      `Linear API: ${res.status} ${res.statusText}` +
+        (errText ? ` — ${errText.slice(0, 400)}` : "")
+    );
   }
 
   const data: any = await res.json();
   if (data.errors?.length) {
-    throw new Error(`Linear API: ${data.errors[0].message}`);
+    const msgs = data.errors.map((e: any) => e.message).join("; ");
+    throw new Error(`Linear API: ${msgs}`);
   }
   return data.data as T;
 }
@@ -141,7 +148,7 @@ export async function fetchTeamActivity(
       }>;
     };
   }>(
-    `query($teamId: String!, $since: DateTime!) {
+    `query($teamId: ID!, $since: DateTimeOrDuration!) {
       issues(
         filter: {
           team: { id: { eq: $teamId } }

--- a/src/services/pipeline.ts
+++ b/src/services/pipeline.ts
@@ -40,6 +40,7 @@ import { fetchTeamActivity, type FetchedLinearIssue } from "./linear";
 import { getProvider, setCustomConfig } from "./llm";
 import { writeMemory, readMemoryContext } from "./memory";
 import { throwIfAborted, isAbortError } from "../lib/abort";
+import { info as logInfo, warn as logWarn } from "@tauri-apps/plugin-log";
 
 // ---- Normalization -------------------------------------------------------
 
@@ -361,8 +362,20 @@ export interface RunResult {
   costUsd: number;
 }
 
+// Narrow `unknown` error values to a readable string for logs.
+function errMessage(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  return String(err);
+}
+
 export async function runWorkflow(opts: RunOptions): Promise<RunResult> {
-  const progress = opts.onProgress || (() => {});
+  // Tee progress events into the log file so every fetch / prune / map /
+  // synthesize / write step is visible in the platform log dir — makes
+  // silent fetch failures diagnosable via `tail -f`.
+  const progress = (stage: string, detail?: string) => {
+    logInfo(`${stage}${detail ? ": " + detail : ""}`).catch(() => {});
+    opts.onProgress?.(stage, detail);
+  };
   const cfg = await getConfig();
   const members = await listMembers();
 
@@ -415,10 +428,11 @@ export async function runWorkflow(opts: RunOptions): Promise<RunResult> {
           timeRange.start,
           fetchOpts
         );
+        progress("fetch", `GitHub: ${repo.owner}/${repo.repo} → ${prs.length} PRs`);
         allItems.push(...normalizeGithub(prs, `${repo.owner}/${repo.repo}`));
       } catch (err) {
         if (isAbortError(err)) throw err;
-        console.warn("github fetch failed", repo, err);
+        logWarn(`github fetch failed (${repo.owner}/${repo.repo}): ${errMessage(err)}`).catch(() => {});
       }
     }
 
@@ -442,10 +456,11 @@ export async function runWorkflow(opts: RunOptions): Promise<RunResult> {
           teamDomain,
           fetchOpts
         );
+        progress("fetch", `Slack: #${ch.name} → ${msgs.length} msgs`);
         allItems.push(...normalizeSlack(msgs));
       } catch (err) {
         if (isAbortError(err)) throw err;
-        console.warn("slack fetch failed", ch, err);
+        logWarn(`slack fetch failed (#${ch.name}): ${errMessage(err)}`).catch(() => {});
       }
     }
 
@@ -459,10 +474,11 @@ export async function runWorkflow(opts: RunOptions): Promise<RunResult> {
           timeRange.start,
           fetchOpts
         );
+        progress("fetch", `Jira: ${proj.key} → ${issues.length} issues`);
         allItems.push(...normalizeJira(issues, proj.key));
       } catch (err) {
         if (isAbortError(err)) throw err;
-        console.warn("jira fetch failed", proj, err);
+        logWarn(`jira fetch failed (${proj.key}): ${errMessage(err)}`).catch(() => {});
       }
     }
 
@@ -477,10 +493,11 @@ export async function runWorkflow(opts: RunOptions): Promise<RunResult> {
           timeRange.start,
           fetchOpts
         );
+        progress("fetch", `Linear: ${team.key} → ${issues.length} issues`);
         allItems.push(...normalizeLinear(issues, team.key));
       } catch (err) {
         if (isAbortError(err)) throw err;
-        console.warn("linear fetch failed", team, err);
+        logWarn(`linear fetch failed (${team.key}): ${errMessage(err)}`).catch(() => {});
       }
     }
 


### PR DESCRIPTION
## Summary

- **Jira**: switch to the enhanced `/rest/api/3/search/jql` endpoint (POST with JSON body). Comments are fetched per issue via `/rest/api/3/issue/{key}/comment` since the new endpoint doesn't include them inline.
- **Linear**: update GraphQL variable types to match the current schema — `$teamId: ID!`, `$since: DateTimeOrDuration!`.
- **Logging**: wire up `tauri-plugin-log` with a file sink at the platform log dir plus stdout + webview targets (10 MB rotation). `main.tsx` calls `attachConsole()` to forward WebView console output; pipeline `progress()` is teed into `log.info()`, and each integration's fetch logs its result count on success or a warn line on failure. HTTP helpers in `jira.ts` / `linear.ts` now include the response body in error messages.

Log file on macOS: `~/Library/Logs/app.keepr.desktop/keepr.log`.

## Test plan
- [ ] Run a 1:1 prep or team pulse with Jira and Linear configured — evidence rows now land as `jira_issue` / `jira_comment` / `linear_issue` / `linear_comment` (previously only `github_pr` appeared).
- [ ] Tail the log file and confirm each fetch step is captured, including counts and failure messages.
- [ ] Build and typecheck green: \`npm run build\`, \`npx tsc --noEmit\`, \`cargo check\` in \`src-tauri/\`.