### PR TITLE
fix: make Keepr plugin discoverable via Claude Code marketplace

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,8 +1,8 @@
 {
-  "name": "keeprhq-keepr",
+  "name": "keeprlabs-keepr",
   "owner": {
-    "name": "keeprhq",
-    "email": "hello@keeprhq.com"
+    "name": "keeprlabs",
+    "email": "hello@keeprlabs.com"
   },
   "plugins": [
     {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,15 @@
+{
+  "name": "keeprhq-keepr",
+  "owner": {
+    "name": "keeprhq",
+    "email": "manikandan.eshwar@gmail.com"
+  },
+  "plugins": [
+    {
+      "name": "keepr",
+      "source": "./plugin",
+      "description": "AI memory layer for engineering leaders — follow-ups, team pulse, 1:1 prep from Claude Code.",
+      "version": "0.2.1"
+    }
+  ]
+}

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -2,14 +2,14 @@
   "name": "keeprhq-keepr",
   "owner": {
     "name": "keeprhq",
-    "email": "manikandan.eshwar@gmail.com"
+    "email": "hello@keeprhq.com"
   },
   "plugins": [
     {
       "name": "keepr",
       "source": "./plugin",
       "description": "AI memory layer for engineering leaders — follow-ups, team pulse, 1:1 prep from Claude Code.",
-      "version": "0.2.1"
+      "version": "0.2.2"
     }
   ]
 }

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: false
 contact_links:
   - name: Discussions
-    url: https://github.com/keeprhq/keepr/discussions
+    url: https://github.com/keeprlabs/keepr/discussions
     about: "Ask usage questions and discuss features in Discussions"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,7 +78,7 @@ jobs:
 
             **Install via Homebrew:**
             ```
-            brew install --cask keeprhq/tap/keepr
+            brew install --cask keeprlabs/tap/keepr
             ```
 
             Or download the `.dmg` below, drag Keepr to Applications.
@@ -175,12 +175,12 @@ jobs:
           chmod 600 ~/.ssh/tap_key
           export GIT_SSH_COMMAND="ssh -i ~/.ssh/tap_key -o StrictHostKeyChecking=no"
 
-          git clone git@github.com:keeprhq/homebrew-tap.git /tmp/homebrew-tap
+          git clone git@github.com:keeprlabs/homebrew-tap.git /tmp/homebrew-tap
           mkdir -p /tmp/homebrew-tap/Casks
           cp homebrew/keepr.rb /tmp/homebrew-tap/Casks/keepr.rb
           cd /tmp/homebrew-tap
           git config user.name "keepr-bot"
-          git config user.email "bot@keeprhq.com"
+          git config user.email "bot@keeprlabs.com"
           git add Casks/keepr.rb
           git diff --cached --quiet || git commit -m "Update keepr to ${{ steps.version.outputs.version }}"
           git push origin main
@@ -191,4 +191,4 @@ jobs:
         if: env.TAP_DEPLOY_KEY == ''
         run: |
           echo "TAP_DEPLOY_KEY not configured. Updated homebrew/keepr.rb locally."
-          echo "To publish: copy homebrew/keepr.rb to the keeprhq/homebrew-tap repo."
+          echo "To publish: copy homebrew/keepr.rb to the keeprlabs/homebrew-tap repo."

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -30,7 +30,7 @@ Plugin lives in `plugin/` with five skills:
 - `keepr-pulse` — trigger team pulse generation
 
 Each skill checks for `keepr` on PATH first. If missing, invokes the setup
-skill which installs via `brew install --cask keeprhq/tap/keepr`.
+skill which installs via `brew install --cask keeprlabs/tap/keepr`.
 
 Update detection: every skill runs `keepr cli check-update` and mentions
 available updates to the user.
@@ -38,7 +38,7 @@ available updates to the user.
 ### Homebrew cask
 
 - `homebrew/keepr.rb` — cask formula installing Keepr.app + symlink to `/usr/local/bin/keepr`
-- Release workflow auto-updates the cask SHA and pushes to `keeprhq/homebrew-tap`
+- Release workflow auto-updates the cask SHA and pushes to `keeprlabs/homebrew-tap`
 
 ### Update notifications
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -27,7 +27,7 @@ This Code of Conduct applies within all community spaces, including issues, pull
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the project maintainers at **keeprhq** on GitHub. All complaints will be reviewed and investigated promptly and fairly.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the project maintainers at **keeprlabs** on GitHub. All complaints will be reviewed and investigated promptly and fairly.
 
 Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, issues, and other contributions that are not aligned to this Code of Conduct.
 

--- a/README.md
+++ b/README.md
@@ -90,9 +90,9 @@ Keepr has a [Claude Code plugin](./plugin/) that lets you capture follow-ups, ch
 # Install the desktop app first
 brew install --cask keeprhq/tap/keepr
 
-# Then add the plugin
+# Then add the plugin marketplace and install
 /plugin marketplace add keeprhq/keepr
-/plugin install keepr@keepr
+/plugin install keepr@keeprhq-keepr
 ```
 
 **Available skills:**

--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@
 </p>
 
 <p align="center">
-  <a href="https://github.com/keeprhq/keepr/blob/main/LICENSE"><img src="https://img.shields.io/badge/License-MIT-blue.svg" alt="License: MIT" /></a>
-  <a href="https://github.com/keeprhq/keepr/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/keeprhq/keepr/ci.yml?branch=main&label=CI" alt="Build Status" /></a>
-  <a href="https://github.com/keeprhq/keepr/releases/latest"><img src="https://img.shields.io/github/v/release/keeprhq/keepr?include_prereleases&label=release" alt="Release" /></a>
+  <a href="https://github.com/keeprlabs/keepr/blob/main/LICENSE"><img src="https://img.shields.io/badge/License-MIT-blue.svg" alt="License: MIT" /></a>
+  <a href="https://github.com/keeprlabs/keepr/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/keeprlabs/keepr/ci.yml?branch=main&label=CI" alt="Build Status" /></a>
+  <a href="https://github.com/keeprlabs/keepr/releases/latest"><img src="https://img.shields.io/github/v/release/keeprlabs/keepr?include_prereleases&label=release" alt="Release" /></a>
 </p>
 
 ---
@@ -57,7 +57,7 @@ Point it at your Slack workspace and a handful of GitHub repos, pick an LLM prov
 You need **Node 20+**, **Rust (stable)**, and **npm**.
 
 ```bash
-git clone https://github.com/keeprhq/keepr.git
+git clone https://github.com/keeprlabs/keepr.git
 cd keepr
 npm install
 npx tauri dev
@@ -88,11 +88,11 @@ Keepr has a [Claude Code plugin](./plugin/) that lets you capture follow-ups, ch
 
 ```bash
 # Install the desktop app first
-brew install --cask keeprhq/tap/keepr
+brew install --cask keeprlabs/tap/keepr
 
 # Then add the plugin marketplace and install
-/plugin marketplace add keeprhq/keepr
-/plugin install keepr@keeprhq-keepr
+/plugin marketplace add keeprlabs/keepr
+/plugin install keepr@keeprlabs-keepr
 ```
 
 **Available skills:**

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -8,7 +8,7 @@ Claude Code plugin and CLI surface.
 
 - **CLI subcommands** — `keepr cli status`, `open`, `add-followup`, `pulse`, `check-update`
 - **Claude Code plugin** — five skills for follow-ups, status, team pulse from the terminal
-- **Homebrew cask** — `brew install --cask keeprhq/tap/keepr` with auto-update on release
+- **Homebrew cask** — `brew install --cask keeprlabs/tap/keepr` with auto-update on release
 - **Update notifications** — desktop banner + CLI check + plugin hints
 
 ## v0.2.0 — shipped

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -11,7 +11,7 @@
 
 If you discover a security vulnerability in Keepr, please report it responsibly. **Do not open a public GitHub issue.**
 
-Email the maintainer directly or use [GitHub's private vulnerability reporting](https://github.com/keeprhq/keepr/security/advisories/new).
+Email the maintainer directly or use [GitHub's private vulnerability reporting](https://github.com/keeprlabs/keepr/security/advisories/new).
 
 When reporting, please include:
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -8,7 +8,7 @@
   <meta property="og:title" content="Keepr" />
   <meta property="og:description" content="AI memory layer for engineering leaders. On-device, privacy-first, open source." />
   <meta property="og:type" content="website" />
-  <meta property="og:url" content="https://keeprhq.github.io/keepr/" />
+  <meta property="og:url" content="https://keeprlabs.github.io/keepr/" />
   <link rel="icon" href="favicon.ico" type="image/x-icon" />
   <style>
     /* --------------------------------------------------------
@@ -360,10 +360,10 @@
         never touches a middleman server.
       </p>
       <div class="cta-row">
-        <a href="https://github.com/keeprhq/keepr/releases/latest" class="btn btn-primary">
+        <a href="https://github.com/keeprlabs/keepr/releases/latest" class="btn btn-primary">
           Download for macOS
         </a>
-        <a href="https://github.com/keeprhq/keepr" class="btn btn-secondary">
+        <a href="https://github.com/keeprlabs/keepr" class="btn btn-secondary">
           View on GitHub
         </a>
       </div>
@@ -422,7 +422,7 @@
       <h2>Get started</h2>
       <div class="code-block">
         <span class="comment"># Clone and run from source</span><br />
-        git clone https://github.com/keeprhq/keepr.git<br />
+        git clone https://github.com/keeprlabs/keepr.git<br />
         cd keepr<br />
         npm install<br />
         npx tauri dev
@@ -433,9 +433,9 @@
       <div class="footer-inner">
         <p>Keepr is MIT-licensed open-source software.</p>
         <nav class="footer-links">
-          <a href="https://github.com/keeprhq/keepr">GitHub</a>
-          <a href="https://github.com/keeprhq/keepr/releases/latest">Releases</a>
-          <a href="https://github.com/keeprhq/keepr/blob/main/CONTRIBUTING.md">Contributing</a>
+          <a href="https://github.com/keeprlabs/keepr">GitHub</a>
+          <a href="https://github.com/keeprlabs/keepr/releases/latest">Releases</a>
+          <a href="https://github.com/keeprlabs/keepr/blob/main/CONTRIBUTING.md">Contributing</a>
         </nav>
       </div>
     </footer>

--- a/homebrew/README.md
+++ b/homebrew/README.md
@@ -1,13 +1,13 @@
 # Homebrew Tap for Keepr
 
 This directory contains the Homebrew cask formula for Keepr. It is automatically
-pushed to the [`keeprhq/homebrew-tap`](https://github.com/keeprhq/homebrew-tap)
+pushed to the [`keeprlabs/homebrew-tap`](https://github.com/keeprlabs/homebrew-tap)
 repository on each release.
 
 ## Install
 
 ```bash
-brew install --cask keeprhq/tap/keepr
+brew install --cask keeprlabs/tap/keepr
 ```
 
 This installs Keepr to `/Applications/Keepr.app` and symlinks the binary to
@@ -27,24 +27,24 @@ brew uninstall --cask keepr
 
 ## Setup for the tap repo
 
-The `keeprhq/homebrew-tap` repo needs:
+The `keeprlabs/homebrew-tap` repo needs:
 
 1. A `Casks/` directory containing `keepr.rb`
 2. A deploy key (`TAP_DEPLOY_KEY` secret in the main keepr repo) with write
-   access to `keeprhq/homebrew-tap`
+   access to `keeprlabs/homebrew-tap`
 
 The release workflow automatically:
 1. Builds the signed DMG
 2. Computes its SHA256
 3. Updates the version and SHA in `keepr.rb`
-4. Pushes to `keeprhq/homebrew-tap`
+4. Pushes to `keeprlabs/homebrew-tap`
 
 ### Creating the tap repo
 
 ```bash
-# Create the repo on GitHub: keeprhq/homebrew-tap
+# Create the repo on GitHub: keeprlabs/homebrew-tap
 # Then:
-git clone git@github.com:keeprhq/homebrew-tap.git
+git clone git@github.com:keeprlabs/homebrew-tap.git
 cd homebrew-tap
 mkdir Casks
 cp /path/to/keepr/homebrew/keepr.rb Casks/
@@ -55,6 +55,6 @@ git add . && git commit -m "Initial cask" && git push
 
 ```bash
 ssh-keygen -t ed25519 -C "keepr-tap-deploy" -f keepr-tap-key -N ""
-# Add keepr-tap-key.pub as a deploy key (with write access) on keeprhq/homebrew-tap
-# Add keepr-tap-key as TAP_DEPLOY_KEY secret on keeprhq/keepr
+# Add keepr-tap-key.pub as a deploy key (with write access) on keeprlabs/homebrew-tap
+# Add keepr-tap-key as TAP_DEPLOY_KEY secret on keeprlabs/keepr
 ```

--- a/homebrew/keepr.rb
+++ b/homebrew/keepr.rb
@@ -1,15 +1,15 @@
 # Homebrew Cask for Keepr — AI memory layer for engineering leaders.
-# This formula is published at keeprhq/homebrew-tap and auto-updated
+# This formula is published at keeprlabs/homebrew-tap and auto-updated
 # by the update-homebrew job in .github/workflows/release.yml.
 
 cask "keepr" do
   version "0.2.1"
   sha256 "PLACEHOLDER_SHA256"
 
-  url "https://github.com/keeprhq/keepr/releases/download/v#{version}/Keepr_#{version}_universal.dmg"
+  url "https://github.com/keeprlabs/keepr/releases/download/v#{version}/Keepr_#{version}_universal.dmg"
   name "Keepr"
   desc "AI memory layer for engineering leaders"
-  homepage "https://keeprhq.github.io/keepr"
+  homepage "https://keeprlabs.github.io/keepr"
 
   livecheck do
     url :url

--- a/plugin/.claude-plugin/marketplace.json
+++ b/plugin/.claude-plugin/marketplace.json
@@ -1,9 +1,0 @@
-{
-  "slug": "keeprhq/keepr",
-  "displayName": "Keepr",
-  "shortDescription": "AI memory layer for engineering leaders — follow-ups, team pulse, 1:1 prep from Claude Code.",
-  "category": "productivity",
-  "iconUrl": "https://keeprhq.github.io/keepr/icon-128.png",
-  "screenshots": [],
-  "installInstructions": "Requires the Keepr desktop app. Install via: brew install --cask keeprhq/tap/keepr"
-}

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -3,11 +3,11 @@
   "version": "0.2.2",
   "description": "AI memory layer for engineering leaders. Trigger Keepr actions from Claude Code; view results in the Keepr desktop app.",
   "author": {
-    "name": "keeprhq",
-    "email": "hello@keeprhq.com"
+    "name": "keeprlabs",
+    "email": "hello@keeprlabs.com"
   },
   "license": "MIT",
-  "homepage": "https://keeprhq.github.io/keepr",
-  "repository": "https://github.com/keeprhq/keepr",
+  "homepage": "https://keeprlabs.github.io/keepr",
+  "repository": "https://github.com/keeprlabs/keepr",
   "keywords": ["engineering", "management", "1on1", "team", "memory", "followups"]
 }

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -2,7 +2,10 @@
   "name": "keepr",
   "version": "0.2.1",
   "description": "AI memory layer for engineering leaders. Trigger Keepr actions from Claude Code; view results in the Keepr desktop app.",
-  "author": "keeprhq",
+  "author": {
+    "name": "keeprhq",
+    "email": "manikandan.eshwar@gmail.com"
+  },
   "license": "MIT",
   "homepage": "https://keeprhq.github.io/keepr",
   "repository": "https://github.com/keeprhq/keepr",

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,10 +1,10 @@
 {
   "name": "keepr",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "AI memory layer for engineering leaders. Trigger Keepr actions from Claude Code; view results in the Keepr desktop app.",
   "author": {
     "name": "keeprhq",
-    "email": "manikandan.eshwar@gmail.com"
+    "email": "hello@keeprhq.com"
   },
   "license": "MIT",
   "homepage": "https://keeprhq.github.io/keepr",

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -1,6 +1,6 @@
 # Keepr Plugin for Claude Code
 
-> **Requires the Keepr desktop app.** Install it first: `brew install --cask keeprhq/tap/keepr`
+> **Requires the Keepr desktop app.** Install it first: `brew install --cask keeprlabs/tap/keepr`
 
 This plugin lets you trigger Keepr actions directly from Claude Code. Follow-ups, status checks, and team pulses — without leaving your terminal.
 
@@ -8,11 +8,11 @@ This plugin lets you trigger Keepr actions directly from Claude Code. Follow-ups
 
 ```bash
 # 1. Install the desktop app (if you haven't)
-brew install --cask keeprhq/tap/keepr
+brew install --cask keeprlabs/tap/keepr
 
 # 2. Add the plugin marketplace and install
-/plugin marketplace add keeprhq/keepr
-/plugin install keepr@keeprhq-keepr
+/plugin marketplace add keeprlabs/keepr
+/plugin install keepr@keeprlabs-keepr
 ```
 
 ## Skills
@@ -44,7 +44,7 @@ brew upgrade --cask keepr
 ## Troubleshooting
 
 **"keepr: command not found"**
-Run `/keepr:keepr-setup` to install, or manually: `brew install --cask keeprhq/tap/keepr`
+Run `/keepr:keepr-setup` to install, or manually: `brew install --cask keeprlabs/tap/keepr`
 
 **"Keepr database not found"**
 Open the desktop app first to complete initial setup: `keepr cli open`

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -10,9 +10,9 @@ This plugin lets you trigger Keepr actions directly from Claude Code. Follow-ups
 # 1. Install the desktop app (if you haven't)
 brew install --cask keeprhq/tap/keepr
 
-# 2. Add the plugin
+# 2. Add the plugin marketplace and install
 /plugin marketplace add keeprhq/keepr
-/plugin install keepr@keepr
+/plugin install keepr@keeprhq-keepr
 ```
 
 ## Skills

--- a/plugin/skills/keepr-add-followup/SKILL.md
+++ b/plugin/skills/keepr-add-followup/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: keepr-add-followup
 description: "Capture a follow-up item in Keepr. Use when the user mentions wanting to remember something for a later 1:1, surface a topic in their next team conversation, track a commitment they made to a team member, or note something to check on later."
 ---
 

--- a/plugin/skills/keepr-open/SKILL.md
+++ b/plugin/skills/keepr-open/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: keepr-open
 description: "Open the Keepr desktop app. Use when the user wants to view sessions, evidence, team heatmap, follow-up tracker, evidence graph, or 1:1 prep visually."
 ---
 

--- a/plugin/skills/keepr-pulse/SKILL.md
+++ b/plugin/skills/keepr-pulse/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: keepr-pulse
 description: "Generate a team pulse in Keepr — a summary of what the team accomplished recently. Use when the user wants a quick read of team activity, asks what the team shipped this week, or wants to prepare for a team standup or all-hands. The result is viewable in the Keepr desktop app."
 ---
 

--- a/plugin/skills/keepr-setup/SKILL.md
+++ b/plugin/skills/keepr-setup/SKILL.md
@@ -35,7 +35,7 @@ which brew 2>/dev/null
 
 **If Homebrew is available**, install via cask:
 ```bash
-brew install --cask keeprhq/tap/keepr
+brew install --cask keeprlabs/tap/keepr
 ```
 
 Then verify:
@@ -53,7 +53,7 @@ keepr cli version
 >
 > Then run:
 > ```
-> brew install --cask keeprhq/tap/keepr
+> brew install --cask keeprlabs/tap/keepr
 > ```
 
 Do NOT attempt to download or install the `.dmg` directly. The Homebrew cask handles signing verification, PATH setup, and future updates.

--- a/plugin/skills/keepr-setup/SKILL.md
+++ b/plugin/skills/keepr-setup/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: keepr-setup
 description: "Install or update the Keepr desktop app. Runs automatically when other Keepr skills detect that keepr is not installed. Can also be invoked manually to check for updates."
 ---
 

--- a/plugin/skills/keepr-status/SKILL.md
+++ b/plugin/skills/keepr-status/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: keepr-status
 description: "Check Keepr configuration and connection status. Use when troubleshooting Keepr, before running other Keepr commands, or when the user asks about their Keepr setup."
 ---
 

--- a/release-v0.2.1.md
+++ b/release-v0.2.1.md
@@ -6,11 +6,11 @@ Use Keepr from your terminal. Capture follow-ups, check status, and trigger team
 
 ```bash
 # Desktop app (required)
-brew install --cask keeprhq/tap/keepr
+brew install --cask keeprlabs/tap/keepr
 
 # Claude Code plugin
-/plugin marketplace add keeprhq/keepr
-/plugin install keepr@keeprhq-keepr
+/plugin marketplace add keeprlabs/keepr
+/plugin install keepr@keeprlabs-keepr
 ```
 
 ## What's new
@@ -50,7 +50,7 @@ Skills activate contextually — mention wanting to track something for a 1:1 an
 ### Homebrew
 
 ```bash
-brew install --cask keeprhq/tap/keepr
+brew install --cask keeprlabs/tap/keepr
 brew upgrade --cask keepr
 ```
 

--- a/release-v0.2.1.md
+++ b/release-v0.2.1.md
@@ -10,7 +10,7 @@ brew install --cask keeprhq/tap/keepr
 
 # Claude Code plugin
 /plugin marketplace add keeprhq/keepr
-/plugin install keepr@keepr
+/plugin install keepr@keeprhq-keepr
 ```
 
 ## What's new

--- a/src-tauri/src/cli.rs
+++ b/src-tauri/src/cli.rs
@@ -17,7 +17,7 @@ use std::path::PathBuf;
 use std::process::Command;
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");
-const GITHUB_REPO: &str = "keeprhq/keepr";
+const GITHUB_REPO: &str = "keeprlabs/keepr";
 
 // ---- DB helpers (via system sqlite3) --------------------------------------
 
@@ -146,7 +146,7 @@ fn cmd_open(session: Option<i64>, prep: Option<String>) -> Result<(), String> {
         format!(
             "Failed to launch Keepr: {e}\n\
              Make sure Keepr.app is in /Applications.\n\
-             Install via: brew install --cask keeprhq/tap/keepr"
+             Install via: brew install --cask keeprlabs/tap/keepr"
         )
     })?;
 

--- a/src/components/UpdateBanner.tsx
+++ b/src/components/UpdateBanner.tsx
@@ -11,7 +11,7 @@ const CURRENT_VERSION: string =
   typeof __KEEPR_VERSION__ !== "undefined" ? __KEEPR_VERSION__ : "0.2.1";
 const CHECK_INTERVAL_MS = 24 * 60 * 60 * 1000; // 24 hours
 const STORAGE_KEY = "keepr_update_check";
-const GITHUB_API = "https://api.github.com/repos/keeprhq/keepr/releases/latest";
+const GITHUB_API = "https://api.github.com/repos/keeprlabs/keepr/releases/latest";
 
 interface CachedCheck {
   checkedAt: number;


### PR DESCRIPTION
## Summary
- Adds `.claude-plugin/marketplace.json` at the repo root so the repo works as a Claude Code plugin marketplace — users can install with `/plugin marketplace add keeprhq/keepr` then `/plugin install keepr@keeprhq-keepr`
- Fixes `plugin.json` author field to use object format (matching official Anthropic plugins)
- Removes misplaced `marketplace.json` from `plugin/.claude-plugin/` (wrong location per spec)
- Adds `name` field to all 5 SKILL.md frontmatter files (required for skill discovery)
- Removes unused `"skills": "skills"` field from plugin.json (auto-discovered by convention)
- Updates install instructions in both README files

## Test plan
- [x] Verified all 5 skills discovered via `claude --plugin-dir ./plugin`
- [x] Verified all 5 skills discovered via `installed_plugins.json` registration
- [x] Verified `/keepr:keepr-setup` skill executes correctly
- [x] Compared plugin structure against working official plugins (frontend-design, rust-analyzer-lsp)

🤖 Generated with [Claude Code](https://claude.com/claude-code)