### PR TITLE
Fix duplicate nodes in evidence graph

### DIFF
--- a/src/screens/ThreadGraph.tsx
+++ b/src/screens/ThreadGraph.tsx
@@ -22,7 +22,16 @@ export function ThreadGraph({ members }: Props) {
         const ev = await listEvidence(s.id);
         allEvidence.push(...ev);
       }
-      setEvidence(allEvidence);
+      // Deduplicate across sessions: keep newest per source+source_id
+      const deduped = new Map<string, EvidenceItem>();
+      for (const ev of allEvidence) {
+        const key = `${ev.source}:${ev.source_id}`;
+        const existing = deduped.get(key);
+        if (!existing || ev.timestamp_at > existing.timestamp_at) {
+          deduped.set(key, ev);
+        }
+      }
+      setEvidence(Array.from(deduped.values()));
     })();
   }, []);
 


### PR DESCRIPTION
## Summary
- Evidence graph rendered duplicate nodes for the same Jira/Linear issue when it appeared across multiple sessions
- Deduplicate evidence items by `source + source_id` before rendering, keeping only the newest entry

## Test plan
- [ ] Open the evidence graph
- [ ] Verify each Jira/Linear issue (e.g. EXLO-103) appears as a single node
- [ ] Verify edges still connect correctly to deduplicated nodes