### PR TITLE
feat: search-and-pick teammate mapping with org-scoped GitHub

### DIFF
--- a/src/components/onboarding/StepGitHub.tsx
+++ b/src/components/onboarding/StepGitHub.tsx
@@ -2,7 +2,7 @@
 // app needed). Device flow is offered as "preferred when available", and
 // only when the installed build has a real client id wired up.
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { open as openExternal } from "@tauri-apps/plugin-shell";
 import {
   Field,
@@ -34,6 +34,23 @@ export function StepGitHub({
   const [login, setLogin] = useState("");
   const [device, setDevice] = useState<github.DeviceCodeResponse | null>(null);
   const [scopeCount, setScopeCount] = useState(0);
+  const [readOrgOK, setReadOrgOK] = useState<boolean | null>(null);
+
+  // After auth lands, probe the granted scopes once. Used to surface a
+  // "Reconnect with read:org enabled" hint inline so users don't get to
+  // the team-mapping step and silently see an empty GitHub picker.
+  useEffect(() => {
+    if (state !== "ok") return;
+    let cancelled = false;
+    (async () => {
+      github.invalidateScopeCache();
+      const ok = await github.hasReadOrgScope().catch(() => false);
+      if (!cancelled) setReadOrgOK(ok);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [state]);
 
   const gateDisabled = state !== "ok" || scopeCount === 0;
   const gateTitle =
@@ -60,7 +77,7 @@ export function StepGitHub({
       setState("err");
       const raw = (e?.message || "").toLowerCase();
       if (raw.includes("401") || raw.includes("bad credentials")) {
-        setError("GitHub rejected that token. Double-check the scopes include repo and read:user.");
+        setError("GitHub rejected that token. Double-check the scopes include repo, read:user, and read:org.");
       } else {
         setError(e?.message || "Token test failed.");
       }
@@ -134,11 +151,11 @@ export function StepGitHub({
                 onClick={(e) => {
                   e.preventDefault();
                   openExternal(
-                    "https://github.com/settings/tokens/new?scopes=repo,read:user&description=Keepr"
+                    "https://github.com/settings/tokens/new?scopes=repo,read:user,read:org&description=Keepr"
                   );
                 }}
               >
-                Create one (scopes: repo, read:user)
+                Create one (scopes: repo, read:user, read:org)
               </button>
             }
           >
@@ -153,6 +170,31 @@ export function StepGitHub({
             />
           </Field>
 
+          {state === "ok" && readOrgOK === false && (
+            <div className="mb-4 rounded-md border border-hairline bg-surface px-3 py-2 text-xs text-ink-soft leading-relaxed">
+              Connected as <span className="mono">{login}</span>, but Keepr
+              can't see your org members yet — the token is missing{" "}
+              <span className="mono">read:org</span>. Reconnect with that
+              scope checked to map teammates from your GitHub orgs.
+              <div className="mt-2">
+                <button
+                  type="button"
+                  onClick={() => {
+                    if (mode === "pat") {
+                      openExternal(
+                        "https://github.com/settings/tokens/new?scopes=repo,read:user,read:org&description=Keepr"
+                      );
+                    } else {
+                      startDevice();
+                    }
+                  }}
+                  className="text-accent hover:underline"
+                >
+                  Reconnect GitHub →
+                </button>
+              </div>
+            </div>
+          )}
           {state === "ok" && (
             <ScopePickerPanel
               integration="github"
@@ -217,6 +259,23 @@ export function StepGitHub({
             </Lede>
           )}
 
+          {state === "ok" && readOrgOK === false && (
+            <div className="mb-4 rounded-md border border-hairline bg-surface px-3 py-2 text-xs text-ink-soft leading-relaxed">
+              Connected as <span className="mono">{login}</span>, but Keepr
+              can't see your org members yet — the token is missing{" "}
+              <span className="mono">read:org</span>. Reconnect with that
+              scope checked to map teammates from your GitHub orgs.
+              <div className="mt-2">
+                <button
+                  type="button"
+                  onClick={() => startDevice()}
+                  className="text-accent hover:underline"
+                >
+                  Reconnect GitHub →
+                </button>
+              </div>
+            </div>
+          )}
           {state === "ok" && (
             <ScopePickerPanel
               integration="github"

--- a/src/components/onboarding/StepTeam.tsx
+++ b/src/components/onboarding/StepTeam.tsx
@@ -1,7 +1,9 @@
-// Team members — fuzzy match GitHub handles against Slack display names,
-// keyboard-first but mouse-accessible. Three columns: name, github, slack.
-// As the manager types a name or handle, a low-key suggestion surfaces
-// under the slack column and can be accepted with Tab or a click.
+// Map each team member to their accounts on every connected provider
+// (Slack, GitHub, Linear, Jira). One row per person, one combobox per
+// provider — no silent cross-field auto-match. The "Find matches" button
+// per row searches all four providers from the display name and shows the
+// candidates for confirmation; the user clicks once to apply, never has
+// to manually re-pick if the heuristic guessed right.
 
 import { useEffect, useMemo, useRef, useState } from "react";
 import {
@@ -12,54 +14,288 @@ import {
   Title,
   inputCls,
 } from "./primitives";
-import { listMembers, upsertMember } from "../../services/db";
-import * as slack from "../../services/slack";
-import { slugify } from "../../services/memory";
+import { UserCombobox } from "./UserCombobox";
 import {
-  bestSlackMatch,
-  fuzzyMatchSlack,
-  slackDisplay,
-} from "./fuzzyMatch";
+  listMembers,
+  upsertMember,
+  getConfig,
+} from "../../services/db";
+import * as slack from "../../services/slack";
+import * as linear from "../../services/linear";
+import * as github from "../../services/github";
+import { slugify } from "../../services/memory";
+import { SECRET_KEYS, getSecret } from "../../services/secrets";
+import {
+  loadGitHubMemberPool,
+  loadJiraUserPool,
+  resolveGitHubLabel,
+  resolveJiraLabel,
+  resolveLinearLabel,
+  resolveSlackLabel,
+  searchGitHub,
+  searchJira,
+  searchLinear,
+  searchSlack,
+  type ProviderUserMatch,
+  type TeammateProvider,
+} from "../../services/teammateSearch";
+import type { GitHubMember } from "../../services/github";
+import type { JiraUser } from "../../services/jira";
+import type { LinearUser } from "../../services/linear";
 
 interface Row {
+  id?: number;
   display_name: string;
   github_handle: string;
+  github_label?: string;
   slack_user_id: string;
-  /** non-persisted: the label we show next to the slack id */
   slack_label?: string;
-  /** non-persisted: whether the current slack id came from an auto-match */
-  auto_matched?: boolean;
+  linear_username: string;
+  linear_label?: string;
+  jira_username: string;
+  jira_label?: string;
 }
 
-const EMPTY_ROW: Row = { display_name: "", github_handle: "", slack_user_id: "" };
+const EMPTY_ROW: Row = {
+  display_name: "",
+  github_handle: "",
+  slack_user_id: "",
+  linear_username: "",
+  jira_username: "",
+};
+
+interface ProviderAvail {
+  slack: boolean;
+  github: boolean;
+  linear: boolean;
+  jira: boolean;
+}
+
+interface ProviderCaches {
+  slack: slack.SlackUser[];
+  linear: LinearUser[];
+  jira: JiraUser[];
+  github: GitHubMember[];
+}
+
+interface SmartFillState {
+  rowIdx: number;
+  candidates: Partial<Record<TeammateProvider, ProviderUserMatch[]>>;
+  loading: boolean;
+}
 
 export function StepTeam({ onNext }: { onNext: () => void }) {
-  const [rows, setRows] = useState<Row[]>([EMPTY_ROW, EMPTY_ROW, EMPTY_ROW]);
-  const [slackUsers, setSlackUsers] = useState<slack.SlackUser[]>([]);
-  const [slackAvailable, setSlackAvailable] = useState(true);
-  const [suggestIdx, setSuggestIdx] = useState<number | null>(null);
-  const rootRef = useRef<HTMLDivElement>(null);
+  const [rows, setRows] = useState<Row[]>([
+    { ...EMPTY_ROW },
+    { ...EMPTY_ROW },
+    { ...EMPTY_ROW },
+  ]);
+  const [avail, setAvail] = useState<ProviderAvail>({
+    slack: false,
+    github: false,
+    linear: false,
+    jira: false,
+  });
+  const [caches, setCaches] = useState<ProviderCaches>({
+    slack: [],
+    linear: [],
+    jira: [],
+    github: [],
+  });
+  const [githubScopeOK, setGithubScopeOK] = useState(true);
+  const [jiraProjectKeys, setJiraProjectKeys] = useState<string[]>([]);
+  const [smart, setSmart] = useState<SmartFillState | null>(null);
+  // In-flight provider-cache loads. Shared between the eager preload
+  // (initial useEffect) and the lazy combobox onLoad path so a focus that
+  // races the preload coalesces against the same promise.
+  const inflightRef = useRef<Partial<Record<TeammateProvider, Promise<void>>>>({});
 
+  // Initial load: existing members + which providers are connected. We
+  // also eagerly preload Slack/Linear/Jira caches when their providers are
+  // connected, so resolving labels for already-mapped members on a cold
+  // reload doesn't show raw "U05XXXXX" Slack IDs while the user waits for
+  // their first focus into a cell to populate the cache.
   useEffect(() => {
+    let cancelled = false;
     (async () => {
       const existing = await listMembers();
+      if (cancelled) return;
       if (existing.length) {
         setRows(
           existing.map((m) => ({
+            id: m.id,
             display_name: m.display_name,
             github_handle: m.github_handle || "",
             slack_user_id: m.slack_user_id || "",
+            linear_username: m.linear_username || "",
+            jira_username: m.jira_username || "",
           }))
         );
       }
-      try {
-        const users = await slack.listUsers();
-        setSlackUsers(users);
-      } catch {
-        setSlackAvailable(false);
+      const [slackTok, ghTok, jiraEmail, jiraTok, linearKey, cfg] = await Promise.all([
+        getSecret(SECRET_KEYS.slackBot),
+        getSecret(SECRET_KEYS.github),
+        getSecret(SECRET_KEYS.jiraEmail),
+        getSecret(SECRET_KEYS.jiraToken),
+        getSecret(SECRET_KEYS.linear),
+        getConfig(),
+      ]);
+      if (cancelled) return;
+      const projectKeys = (cfg.selected_jira_projects || []).map((p) => p.key);
+      const availability = {
+        slack: !!slackTok,
+        github: !!ghTok,
+        linear: !!linearKey,
+        jira: !!(jiraEmail && jiraTok && projectKeys.length),
+      };
+      setAvail(availability);
+      setJiraProjectKeys(projectKeys);
+
+      // Preload connected provider caches in parallel. Each is best-effort:
+      // a fetch failure for one provider must not block the others. We
+      // also seed inflightRef so a combobox focus that races the preload
+      // shares the in-flight promise instead of firing a second request.
+      const tasks: Array<Promise<void>> = [];
+      const seed = <P extends "slack" | "linear" | "jira" | "github">(
+        p: P,
+        promise: Promise<void>
+      ) => {
+        inflightRef.current[p] = promise;
+        tasks.push(promise);
+      };
+      if (availability.slack) {
+        seed(
+          "slack",
+          slack
+            .listUsers()
+            .then((users) => {
+              if (!cancelled) setCaches((c) => ({ ...c, slack: users }));
+            })
+            .catch(() => {})
+            .finally(() => {
+              inflightRef.current.slack = undefined;
+            })
+        );
       }
+      if (availability.linear) {
+        seed(
+          "linear",
+          linear
+            .listOrgMembers()
+            .then((users) => {
+              if (!cancelled) setCaches((c) => ({ ...c, linear: users }));
+            })
+            .catch(() => {})
+            .finally(() => {
+              inflightRef.current.linear = undefined;
+            })
+        );
+      }
+      if (availability.jira) {
+        seed(
+          "jira",
+          loadJiraUserPool(projectKeys)
+            .then((users) => {
+              if (!cancelled) setCaches((c) => ({ ...c, jira: users }));
+            })
+            .catch(() => {})
+            .finally(() => {
+              inflightRef.current.jira = undefined;
+            })
+        );
+      }
+      if (availability.github) {
+        // Probe scope first so we can show a re-auth prompt rather than
+        // silently returning an empty pool when the user's old token
+        // doesn't have read:org.
+        tasks.push(
+          (async () => {
+            const ok = await github.hasReadOrgScope().catch(() => false);
+            if (cancelled) return;
+            setGithubScopeOK(ok);
+            if (!ok) return;
+            try {
+              const members = await loadGitHubMemberPool();
+              if (!cancelled) setCaches((c) => ({ ...c, github: members }));
+            } catch {
+              // pool fetch failed (network, rate limit) — leave empty
+            }
+          })()
+        );
+      }
+      await Promise.all(tasks);
     })();
+    return () => {
+      cancelled = true;
+    };
   }, []);
+
+  // Loaders for the combobox onLoad hook. With eager preload above these
+  // are usually no-ops, but they remain as a safety net for the case where
+  // the first mount-load is still in flight when a user focuses a cell.
+  // Coalescing via inflightRef ensures concurrent focuses share work, and
+  // .finally() always clears the slot — even on rejection, so a transient
+  // 401 doesn't poison the slot for the rest of the session.
+  const loaders = useMemo(
+    () => ({
+      slack: () => {
+        if (caches.slack.length) return Promise.resolve();
+        if (inflightRef.current.slack) return inflightRef.current.slack;
+        const p = slack
+          .listUsers()
+          .then((users) => {
+            setCaches((c) => ({ ...c, slack: users }));
+          })
+          .finally(() => {
+            inflightRef.current.slack = undefined;
+          });
+        inflightRef.current.slack = p;
+        return p;
+      },
+      linear: () => {
+        if (caches.linear.length) return Promise.resolve();
+        if (inflightRef.current.linear) return inflightRef.current.linear;
+        const p = linear
+          .listOrgMembers()
+          .then((users) => {
+            setCaches((c) => ({ ...c, linear: users }));
+          })
+          .finally(() => {
+            inflightRef.current.linear = undefined;
+          });
+        inflightRef.current.linear = p;
+        return p;
+      },
+      jira: () => {
+        if (caches.jira.length) return Promise.resolve();
+        if (inflightRef.current.jira) return inflightRef.current.jira;
+        const p = loadJiraUserPool(jiraProjectKeys)
+          .then((users) => {
+            setCaches((c) => ({ ...c, jira: users }));
+          })
+          .finally(() => {
+            inflightRef.current.jira = undefined;
+          });
+        inflightRef.current.jira = p;
+        return p;
+      },
+      github: () => {
+        if (caches.github.length) return Promise.resolve();
+        if (!githubScopeOK) return Promise.resolve();
+        if (inflightRef.current.github) return inflightRef.current.github;
+        const p = loadGitHubMemberPool()
+          .then((members) => {
+            setCaches((c) => ({ ...c, github: members }));
+          })
+          .finally(() => {
+            inflightRef.current.github = undefined;
+          });
+        inflightRef.current.github = p;
+        return p;
+      },
+    }),
+    [caches, jiraProjectKeys, githubScopeOK]
+  );
 
   const update = (i: number, patch: Partial<Row>) => {
     setRows((prev) => {
@@ -69,51 +305,77 @@ export function StepTeam({ onNext }: { onNext: () => void }) {
     });
   };
 
-  // Auto-match slack id from github handle / display name as the user types,
-  // but ONLY when the slack field is empty or still auto-matched. Never
-  // stomp on a manual selection.
-  const tryAutoMatch = (i: number, handle: string, displayName: string) => {
-    if (!slackUsers.length) return;
-    const current = rows[i];
-    if (current.slack_user_id && !current.auto_matched) return;
-    const q = handle.trim() || displayName.trim();
-    if (!q) {
-      if (current.auto_matched) {
-        update(i, { slack_user_id: "", slack_label: "", auto_matched: false });
-      }
-      return;
-    }
-    const match = bestSlackMatch(q, slackUsers);
-    if (match) {
-      update(i, {
-        slack_user_id: match.id,
-        slack_label: slackDisplay(match),
-        auto_matched: true,
-      });
-    }
-  };
-
-  const suggestionsFor = useMemo(() => {
-    return (i: number) => {
-      const r = rows[i];
-      if (!slackUsers.length) return [];
-      const q = r.github_handle.trim() || r.display_name.trim();
-      if (!q) return [];
-      return fuzzyMatchSlack(q, slackUsers, 4);
-    };
-  }, [rows, slackUsers]);
-
-  const addRow = () => setRows((prev) => [...prev, EMPTY_ROW]);
+  const addRow = () => setRows((prev) => [...prev, { ...EMPTY_ROW }]);
   const removeRow = (i: number) =>
     setRows((prev) => (prev.length > 1 ? prev.filter((_, j) => j !== i) : prev));
+
+  // ── Smart-fill: search all 4 providers from display_name in parallel ──
+  const runSmartFill = async (i: number) => {
+    const r = rows[i];
+    const name = r.display_name.trim();
+    if (!name) return;
+    setSmart({ rowIdx: i, candidates: {}, loading: true });
+
+    // Make sure caches we need are loaded before searching.
+    await Promise.all([
+      avail.slack ? loaders.slack() : Promise.resolve(),
+      avail.linear ? loaders.linear() : Promise.resolve(),
+      avail.jira ? loaders.jira() : Promise.resolve(),
+      avail.github && githubScopeOK ? loaders.github() : Promise.resolve(),
+    ]);
+
+    const out: Partial<Record<TeammateProvider, ProviderUserMatch[]>> = {};
+    if (avail.slack) {
+      out.slack = searchSlack(name, caches.slack, 4);
+    }
+    if (avail.linear) {
+      out.linear = searchLinear(name, caches.linear, 4);
+    }
+    if (avail.jira) {
+      out.jira = searchJira(name, caches.jira, 4);
+    }
+    if (avail.github && githubScopeOK) {
+      out.github = searchGitHub(name, caches.github, 4);
+    }
+    setSmart({ rowIdx: i, candidates: out, loading: false });
+  };
+
+  // Apply smart-fill picks, but never overwrite a column the user already set.
+  const applySmartFill = (picks: Partial<Record<TeammateProvider, ProviderUserMatch>>) => {
+    if (!smart) return;
+    const i = smart.rowIdx;
+    const r = rows[i];
+    const patch: Partial<Row> = {};
+    if (picks.slack && !r.slack_user_id) {
+      patch.slack_user_id = picks.slack.handle;
+      patch.slack_label = picks.slack.label;
+    }
+    if (picks.github && !r.github_handle) {
+      patch.github_handle = picks.github.handle;
+      patch.github_label = picks.github.label;
+    }
+    if (picks.linear && !r.linear_username) {
+      patch.linear_username = picks.linear.handle;
+      patch.linear_label = picks.linear.label;
+    }
+    if (picks.jira && !r.jira_username) {
+      patch.jira_username = picks.jira.handle;
+      patch.jira_label = picks.jira.label;
+    }
+    update(i, patch);
+    setSmart(null);
+  };
 
   const save = async () => {
     for (const r of rows) {
       if (!r.display_name.trim()) continue;
       await upsertMember({
+        id: r.id,
         display_name: r.display_name.trim(),
         github_handle: r.github_handle.trim() || null,
         slack_user_id: r.slack_user_id.trim() || null,
+        linear_username: r.linear_username.trim() || null,
+        jira_username: r.jira_username.trim() || null,
         slug: slugify(r.display_name),
       });
     }
@@ -121,145 +383,187 @@ export function StepTeam({ onNext }: { onNext: () => void }) {
   };
 
   const nonEmptyCount = rows.filter((r) => r.display_name.trim()).length;
+  const anyProviderConnected = avail.slack || avail.github || avail.linear || avail.jira;
+
+  // ── Combobox factories ────────────────────────────────────────────────
+
+  const slackCombo = (i: number, r: Row) => (
+    <UserCombobox
+      provider="slack"
+      value={r.slack_user_id || null}
+      label={r.slack_label}
+      disabled={!avail.slack}
+      disabledHint="Connect Slack to map"
+      placeholder="Search Slack…"
+      initialSeed={r.display_name}
+      search={(q) => searchSlack(q, caches.slack)}
+      onLoad={loaders.slack}
+      resolveLabel={async (h) => resolveSlackLabel(h, caches.slack)}
+      onChange={(m) =>
+        update(i, {
+          slack_user_id: m?.handle ?? "",
+          slack_label: m?.label,
+        })
+      }
+    />
+  );
+
+  const githubDisabled = !avail.github || !githubScopeOK;
+  const githubDisabledHint = !avail.github
+    ? "Connect GitHub to map"
+    : !githubScopeOK
+      ? "Reconnect GitHub with read:org scope"
+      : undefined;
+  const githubCombo = (i: number, r: Row) => (
+    <UserCombobox
+      provider="github"
+      value={r.github_handle || null}
+      label={r.github_label}
+      disabled={githubDisabled}
+      disabledHint={githubDisabledHint}
+      placeholder="Search GitHub…"
+      initialSeed={r.display_name}
+      search={(q) => searchGitHub(q, caches.github)}
+      onLoad={loaders.github}
+      resolveLabel={async (h) => resolveGitHubLabel(h, caches.github)}
+      onChange={(m) =>
+        update(i, {
+          github_handle: m?.handle ?? "",
+          github_label: m?.label,
+        })
+      }
+    />
+  );
+
+  const linearCombo = (i: number, r: Row) => (
+    <UserCombobox
+      provider="linear"
+      value={r.linear_username || null}
+      label={r.linear_label}
+      disabled={!avail.linear}
+      disabledHint="Connect Linear to map"
+      placeholder="Search Linear…"
+      initialSeed={r.display_name}
+      search={(q) => searchLinear(q, caches.linear)}
+      onLoad={loaders.linear}
+      resolveLabel={async (h) => resolveLinearLabel(h, caches.linear)}
+      onChange={(m) =>
+        update(i, {
+          linear_username: m?.handle ?? "",
+          linear_label: m?.label,
+        })
+      }
+    />
+  );
+
+  const jiraCombo = (i: number, r: Row) => (
+    <UserCombobox
+      provider="jira"
+      value={r.jira_username || null}
+      label={r.jira_label}
+      disabled={!avail.jira}
+      disabledHint="Connect Jira to map"
+      placeholder="Search Jira…"
+      initialSeed={r.display_name}
+      search={(q) => searchJira(q, caches.jira)}
+      onLoad={loaders.jira}
+      resolveLabel={async (h) => resolveJiraLabel(h, caches.jira)}
+      onChange={(m) =>
+        update(i, {
+          jira_username: m?.handle ?? "",
+          jira_label: m?.label,
+        })
+      }
+    />
+  );
 
   return (
-    <div ref={rootRef}>
+    <div>
       <Title>Who's on your team?</Title>
       <Lede>
-        Map each person to their GitHub handle and Slack user id. Keepr
-        uses this to thread activity across both sources into one story
-        per person.
-        {!slackAvailable && (
-          <> Slack isn't connected yet — you can come back to this later.</>
-        )}
+        Map each person to their accounts on every connected tool. Type the
+        name, then click <em>Find matches</em> — Keepr searches Slack, GitHub,
+        Linear, and Jira in parallel and shows you the top match for each.
+        Confirm with one click. Manual override is always one focus away.
       </Lede>
 
-      <div className="mb-2 grid grid-cols-[1.25fr_1fr_1.25fr_auto] gap-2 px-1 text-[10px] uppercase tracking-[0.14em] text-ink-faint">
+      {!anyProviderConnected && (
+        <div className="mb-6 rounded-md border border-hairline bg-surface px-3 py-2 text-xs text-ink-soft">
+          No providers connected yet. You can still add names here and come
+          back to map accounts after connecting Slack / GitHub / Linear / Jira.
+        </div>
+      )}
+
+      {avail.github && !githubScopeOK && (
+        <div className="mb-6 rounded-md border border-hairline bg-surface px-3 py-2 text-xs text-ink-soft">
+          GitHub is missing the <span className="mono">read:org</span> scope.
+          Reconnect GitHub in Settings to load your org members.
+        </div>
+      )}
+      {avail.github && githubScopeOK && caches.github.length === 0 && (
+        <div className="mb-6 rounded-md border border-hairline bg-surface px-3 py-2 text-xs text-ink-soft">
+          GitHub connected, but you don't appear to belong to any GitHub
+          orgs — there are no teammates to map from GitHub.
+        </div>
+      )}
+
+      <div className="mb-2 grid grid-cols-[1.1fr_1fr_1fr_1fr_1fr_auto] gap-2 px-1 text-[10px] uppercase tracking-[0.14em] text-ink-faint">
         <span>Name</span>
         <span>GitHub</span>
         <span>Slack</span>
+        <span>Linear</span>
+        <span>Jira</span>
         <span />
       </div>
 
-      <div className="mb-4 flex flex-col gap-[6px]">
-        {rows.map((r, i) => {
-          const suggestions = suggestionsFor(i);
-          const showDropdown =
-            suggestIdx === i &&
-            !r.slack_user_id &&
-            suggestions.length > 0 &&
-            !r.auto_matched;
-          return (
-            <div
-              key={i}
-              className="relative grid grid-cols-[1.25fr_1fr_1.25fr_auto] gap-2 items-start"
-            >
+      <div className="mb-4 flex flex-col gap-2">
+        {rows.map((r, i) => (
+          <div key={i} className="flex flex-col gap-1.5">
+            <div className="grid grid-cols-[1.1fr_1fr_1fr_1fr_1fr_auto] gap-2 items-start">
               <input
                 className={inputCls}
                 placeholder="Display name"
                 value={r.display_name}
-                onChange={(e) => {
-                  update(i, { display_name: e.target.value });
-                  tryAutoMatch(i, r.github_handle, e.target.value);
-                }}
+                onChange={(e) => update(i, { display_name: e.target.value })}
               />
-              <input
-                className={inputCls}
-                placeholder="github-handle"
-                value={r.github_handle}
-                onChange={(e) => {
-                  update(i, { github_handle: e.target.value });
-                  tryAutoMatch(i, e.target.value, r.display_name);
-                }}
-              />
-              <div className="relative">
-                <input
-                  className={inputCls}
-                  placeholder={
-                    slackUsers.length
-                      ? "Suggested from handle…"
-                      : "U01… (Slack user id)"
-                  }
-                  value={
-                    r.slack_label
-                      ? `${r.slack_label}  ·  ${r.slack_user_id}`
-                      : r.slack_user_id
-                  }
-                  onFocus={() => setSuggestIdx(i)}
-                  onBlur={() => {
-                    // Delay so a click on a suggestion is registered first.
-                    setTimeout(() => {
-                      setSuggestIdx((cur) => (cur === i ? null : cur));
-                    }, 120);
-                  }}
-                  onChange={(e) => {
-                    const v = e.target.value;
-                    // If the user types raw, clear the friendly label and
-                    // drop the auto_matched flag.
-                    update(i, {
-                      slack_user_id: v,
-                      slack_label: "",
-                      auto_matched: false,
-                    });
-                  }}
-                  onKeyDown={(e) => {
-                    if (e.key === "Tab" && suggestions[0] && !r.slack_user_id) {
-                      e.preventDefault();
-                      update(i, {
-                        slack_user_id: suggestions[0].user.id,
-                        slack_label: slackDisplay(suggestions[0].user),
-                        auto_matched: true,
-                      });
-                    }
-                    if (e.key === "Escape") {
-                      setSuggestIdx(null);
-                    }
-                  }}
-                />
-                {r.auto_matched && (
-                  <span
-                    className="absolute right-2 top-1/2 -translate-y-1/2 text-[9px] uppercase tracking-[0.14em] text-ink-faint pointer-events-none"
-                    aria-label="auto-matched from Slack"
-                  >
-                    auto
-                  </span>
-                )}
-                {showDropdown && (
-                  <div className="absolute left-0 right-0 top-full z-10 mt-1 overflow-hidden rounded-md border border-hairline bg-canvas shadow-soft">
-                    {suggestions.map(({ user, score }) => (
-                      <button
-                        key={user.id}
-                        onMouseDown={(e) => {
-                          e.preventDefault();
-                          update(i, {
-                            slack_user_id: user.id,
-                            slack_label: slackDisplay(user),
-                            auto_matched: false,
-                          });
-                          setSuggestIdx(null);
-                        }}
-                        className="flex w-full items-center justify-between px-3 py-2 text-left text-xs text-ink-soft hover:bg-surface transition-colors"
-                      >
-                        <span className="truncate">{slackDisplay(user)}</span>
-                        <span className="mono text-[10px] text-ink-faint">
-                          {user.id} · {score}
-                        </span>
-                      </button>
-                    ))}
-                  </div>
-                )}
-              </div>
+              {githubCombo(i, r)}
+              {slackCombo(i, r)}
+              {linearCombo(i, r)}
+              {jiraCombo(i, r)}
               <button
                 onClick={() => removeRow(i)}
-                className="text-xs text-ink-faint hover:text-ink transition-colors px-1"
+                className="text-xs text-ink-faint hover:text-ink transition-colors px-1 self-center"
                 aria-label="Remove row"
                 tabIndex={-1}
               >
                 ✕
               </button>
             </div>
-          );
-        })}
+            <div className="flex items-center gap-3 px-1">
+              <button
+                type="button"
+                onClick={() => runSmartFill(i)}
+                disabled={!r.display_name.trim() || !anyProviderConnected}
+                className="text-[11px] text-ink-faint hover:text-ink underline-offset-2 hover:underline disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+              >
+                Find matches across all
+              </button>
+              {smart?.rowIdx === i && smart.loading && (
+                <span className="text-[11px] text-ink-faint breathing">
+                  Searching all providers…
+                </span>
+              )}
+              {smart?.rowIdx === i && !smart.loading && (
+                <SmartFillPanel
+                  candidates={smart.candidates}
+                  row={r}
+                  onApply={applySmartFill}
+                  onCancel={() => setSmart(null)}
+                />
+              )}
+            </div>
+          </div>
+        ))}
       </div>
 
       <div className="mb-8">
@@ -270,10 +574,106 @@ export function StepTeam({ onNext }: { onNext: () => void }) {
         <PrimaryButton onClick={save} disabled={nonEmptyCount === 0}>
           Save {nonEmptyCount} {nonEmptyCount === 1 ? "member" : "members"}
         </PrimaryButton>
-        <span className="text-xs text-ink-faint">
-          Tab to accept the suggestion · Esc to clear
-        </span>
       </StepFooter>
+    </div>
+  );
+}
+
+// ── Smart-fill confirmation panel ─────────────────────────────────────────
+
+function SmartFillPanel({
+  candidates,
+  row,
+  onApply,
+  onCancel,
+}: {
+  candidates: Partial<Record<TeammateProvider, ProviderUserMatch[]>>;
+  row: Row;
+  onApply: (picks: Partial<Record<TeammateProvider, ProviderUserMatch>>) => void;
+  onCancel: () => void;
+}) {
+  // Default pick = top candidate per provider. Computed once at mount —
+  // safe because the parent only renders this after candidates are ready.
+  const [picks, setPicks] = useState(() => {
+    const initial: Partial<Record<TeammateProvider, ProviderUserMatch>> = {};
+    for (const p of ["slack", "github", "linear", "jira"] as const) {
+      const list = candidates[p] || [];
+      if (list.length) initial[p] = list[0];
+    }
+    return initial;
+  });
+
+  const present: TeammateProvider[] = (["slack", "github", "linear", "jira"] as const).filter(
+    (p) => (candidates[p] || []).length > 0
+  );
+
+  if (!present.length) {
+    return (
+      <span className="text-[11px] text-ink-faint">
+        No matches found.{" "}
+        <button onClick={onCancel} className="underline hover:text-ink">
+          Dismiss
+        </button>
+      </span>
+    );
+  }
+
+  const alreadySetMessage = (p: TeammateProvider): string | null => {
+    if (p === "slack" && row.slack_user_id) return "Already set — won't overwrite";
+    if (p === "github" && row.github_handle) return "Already set — won't overwrite";
+    if (p === "linear" && row.linear_username) return "Already set — won't overwrite";
+    if (p === "jira" && row.jira_username) return "Already set — won't overwrite";
+    return null;
+  };
+
+  return (
+    <div className="flex flex-col gap-1 rounded-md border border-hairline bg-surface px-3 py-2 text-xs">
+      {present.map((p) => {
+        const list = candidates[p] || [];
+        const skip = alreadySetMessage(p);
+        return (
+          <div key={p} className="flex items-center gap-2">
+            <span className="w-14 uppercase tracking-[0.14em] text-[10px] text-ink-faint">
+              {p}
+            </span>
+            {skip ? (
+              <span className="text-ink-faint italic">{skip}</span>
+            ) : (
+              <select
+                className="rounded border border-hairline bg-canvas px-2 py-0.5 text-xs"
+                value={picks[p]?.id || ""}
+                onChange={(e) => {
+                  const next = list.find((x) => x.id === e.target.value);
+                  setPicks((s) => ({ ...s, [p]: next }));
+                }}
+              >
+                {list.map((m) => (
+                  <option key={m.id} value={m.id}>
+                    {m.label}
+                    {m.detail ? ` — ${m.detail}` : ""}
+                  </option>
+                ))}
+              </select>
+            )}
+          </div>
+        );
+      })}
+      <div className="mt-1 flex items-center gap-2">
+        <button
+          type="button"
+          onClick={() => onApply(picks)}
+          className="rounded bg-ink px-2 py-1 text-[11px] text-canvas hover:bg-ink-soft"
+        >
+          Apply
+        </button>
+        <button
+          type="button"
+          onClick={onCancel}
+          className="text-[11px] text-ink-faint hover:text-ink"
+        >
+          Cancel
+        </button>
+      </div>
     </div>
   );
 }

--- a/src/components/onboarding/UserCombobox.tsx
+++ b/src/components/onboarding/UserCombobox.tsx
@@ -1,0 +1,338 @@
+// Real search-and-pick combobox for mapping a team member to a provider
+// account. Replaces the native <select> dropdowns in Settings and the
+// free-text inputs in StepTeam. Single component, used in both places.
+//
+// Behaviour:
+//   - On focus: trigger onLoad once (idempotent — caches in the parent).
+//   - As user types: debounce 150ms, call search(query), show top matches.
+//   - Arrow-up/down to navigate, Enter or click to select. Esc closes.
+//   - Once a value is picked, the input shows the resolved label with a
+//     small "×" affordance to clear it. Typing again reopens search.
+//   - Clearing the text input does NOT clear the value — you must hit "×".
+//     This avoids the silent-overwrite class of bug.
+//   - For network-backed search (GitHub), aborts in-flight on query change.
+//   - resolveLabel runs once on mount when value is set without a label,
+//     so reloading from DB still shows a friendly name.
+
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import { inputCls } from "./primitives";
+import type { ProviderUserMatch, TeammateProvider } from "../../services/teammateSearch";
+
+export interface UserComboboxProps {
+  provider: TeammateProvider;
+  /** Persisted handle (slack id, github login, jira/linear displayName). */
+  value: string | null;
+  /** Pre-known label for `value`. If null, resolveLabel runs on mount. */
+  label?: string | null;
+  /**
+   * Selected match → parent persists. Match is null when user clears via "×".
+   */
+  onChange: (match: ProviderUserMatch | null) => void;
+  /** Called on the first focus to lazy-load any cache the search() needs. */
+  onLoad?: () => Promise<void> | void;
+  /** Sync (cache-backed) or async (network-backed) candidate search. */
+  search: (query: string, signal?: AbortSignal) => ProviderUserMatch[] | Promise<ProviderUserMatch[]>;
+  /** One-shot label resolution for `value` after a cold reload. */
+  resolveLabel?: (handle: string) => Promise<string | null>;
+  placeholder?: string;
+  disabled?: boolean;
+  disabledHint?: string;
+  /** Used to seed the search input's initial query when first opened. */
+  initialSeed?: string;
+  /**
+   * Optional extra classes. Inherits the standard onboarding input shell
+   * via `inputCls`.
+   */
+  className?: string;
+}
+
+const DEBOUNCE_MS = 150;
+
+export function UserCombobox({
+  provider,
+  value,
+  label,
+  onChange,
+  onLoad,
+  search,
+  resolveLabel,
+  placeholder,
+  disabled,
+  disabledHint,
+  initialSeed,
+  className,
+}: UserComboboxProps) {
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState("");
+  const [results, setResults] = useState<ProviderUserMatch[]>([]);
+  const [highlight, setHighlight] = useState(0);
+  const [loading, setLoading] = useState(false);
+  const [resolved, setResolved] = useState<string | null>(label ?? null);
+  const loadedRef = useRef(false);
+  const abortRef = useRef<AbortController | null>(null);
+  const debounceRef = useRef<number | null>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  // Resolve label once, on first mount or when the persisted value changes
+  // out from under us. Skip when the parent already supplied a label.
+  useEffect(() => {
+    if (label) {
+      setResolved(label);
+      return;
+    }
+    if (!value || !resolveLabel) {
+      setResolved(null);
+      return;
+    }
+    let cancelled = false;
+    (async () => {
+      try {
+        const r = await resolveLabel(value);
+        if (!cancelled) setResolved(r);
+      } catch {
+        if (!cancelled) setResolved(null);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [value, label, resolveLabel]);
+
+  // Click-outside closes the dropdown.
+  useEffect(() => {
+    if (!open) return;
+    function onDoc(e: MouseEvent) {
+      if (!containerRef.current) return;
+      if (!containerRef.current.contains(e.target as Node)) setOpen(false);
+    }
+    document.addEventListener("mousedown", onDoc);
+    return () => document.removeEventListener("mousedown", onDoc);
+  }, [open]);
+
+  // Debounced search whenever the user-visible query changes while open.
+  useEffect(() => {
+    if (!open) return;
+    if (debounceRef.current !== null) {
+      window.clearTimeout(debounceRef.current);
+    }
+    debounceRef.current = window.setTimeout(() => {
+      runSearch(query);
+    }, DEBOUNCE_MS);
+    return () => {
+      if (debounceRef.current !== null) {
+        window.clearTimeout(debounceRef.current);
+      }
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [query, open]);
+
+  const runSearch = useCallback(
+    async (q: string) => {
+      if (abortRef.current) abortRef.current.abort();
+      const ac = new AbortController();
+      abortRef.current = ac;
+      setLoading(true);
+      try {
+        const r = await search(q, ac.signal);
+        if (!ac.signal.aborted) {
+          setResults(r);
+          setHighlight(0);
+        }
+      } catch (err: any) {
+        if (ac.signal.aborted) return;
+        if (err?.name === "AbortError") return;
+        setResults([]);
+      } finally {
+        // Always clear loading. The next runSearch will set it again — this
+        // avoids leaving a stale spinner up if the user closes the dropdown
+        // while a request is mid-flight.
+        setLoading(false);
+      }
+    },
+    [search]
+  );
+
+  // Abort any in-flight search when the combobox unmounts (row removed
+  // from StepTeam, Settings panel collapsed, etc).
+  useEffect(() => {
+    return () => abortRef.current?.abort();
+  }, []);
+
+  const handleFocus = useCallback(async () => {
+    if (disabled) return;
+    if (!loadedRef.current && onLoad) {
+      loadedRef.current = true;
+      try {
+        await onLoad();
+      } catch {
+        // The parent can surface load errors; the combobox just renders
+        // whatever the search() returns (empty list is fine).
+      }
+    }
+    if (!open) {
+      // Seed the query the first time we open if no value is set yet.
+      if (!value && !query && initialSeed) setQuery(initialSeed);
+      setOpen(true);
+      runSearch(value ? "" : query || initialSeed || "");
+    }
+  }, [disabled, onLoad, open, value, query, initialSeed, runSearch]);
+
+  const choose = useCallback(
+    (m: ProviderUserMatch) => {
+      onChange(m);
+      setResolved(m.label);
+      setQuery("");
+      setOpen(false);
+      // Drop focus so a subsequent focus reopens fresh.
+      inputRef.current?.blur();
+    },
+    [onChange]
+  );
+
+  const clear = useCallback(() => {
+    onChange(null);
+    setResolved(null);
+    setQuery("");
+    setOpen(false);
+    inputRef.current?.focus();
+  }, [onChange]);
+
+  // Display text — when closed and a value is set, show the resolved label.
+  // When the combobox is open the user is searching, so we show their query.
+  const displayValue = open
+    ? query
+    : resolved
+      ? resolved
+      : value
+        ? value
+        : "";
+
+  const onKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (disabled) return;
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      if (!open) {
+        handleFocus();
+        return;
+      }
+      setHighlight((h) => Math.min(h + 1, Math.max(0, results.length - 1)));
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      setHighlight((h) => Math.max(0, h - 1));
+    } else if (e.key === "Enter") {
+      if (open && results[highlight]) {
+        e.preventDefault();
+        choose(results[highlight]);
+      }
+    } else if (e.key === "Escape") {
+      e.preventDefault();
+      setOpen(false);
+    } else if (e.key === "Backspace" && !query && resolved) {
+      // Edge case: if the input is empty (showing resolved label as
+      // placeholder-like text), Backspace shouldn't silently clear the
+      // value. User must use the × affordance.
+      e.preventDefault();
+    }
+  };
+
+  const inputClass = useMemo(
+    () => `${inputCls} ${disabled ? "opacity-50 cursor-not-allowed" : ""} ${className || ""}`,
+    [disabled, className]
+  );
+
+  return (
+    <div ref={containerRef} className="relative">
+      <input
+        ref={inputRef}
+        type="text"
+        role="combobox"
+        aria-expanded={open}
+        aria-autocomplete="list"
+        aria-disabled={disabled || undefined}
+        aria-label={`Pick ${provider} user`}
+        className={inputClass + " pr-7"}
+        placeholder={
+          disabled ? disabledHint || `${provider} not connected` : placeholder || `Search ${provider}…`
+        }
+        value={displayValue}
+        disabled={disabled}
+        readOnly={!open && !!resolved}
+        onFocus={handleFocus}
+        onChange={(e) => {
+          if (disabled) return;
+          if (!open) setOpen(true);
+          setQuery(e.target.value);
+        }}
+        onKeyDown={onKeyDown}
+      />
+      {/* clear / spinner / chevron — single anchor, swap based on state */}
+      <span
+        className="pointer-events-none absolute right-2 top-1/2 -translate-y-1/2 flex items-center gap-1 text-ink-faint"
+        aria-hidden
+      >
+        {loading && open ? (
+          <span className="text-[10px] tracking-[0.18em] uppercase breathing">…</span>
+        ) : null}
+      </span>
+      {!disabled && value && !open && (
+        <button
+          type="button"
+          onClick={(e) => {
+            e.stopPropagation();
+            clear();
+          }}
+          aria-label="Clear selection"
+          className="absolute right-2 top-1/2 -translate-y-1/2 text-ink-faint hover:text-ink text-xs leading-none"
+        >
+          ×
+        </button>
+      )}
+      {open && !disabled && (
+        <div
+          role="listbox"
+          aria-label={`${provider} user search results`}
+          className="absolute left-0 top-full z-30 mt-1 min-w-full w-max max-w-[360px] max-h-[260px] overflow-y-auto rounded-md border border-hairline bg-canvas shadow-soft"
+        >
+          {results.length === 0 && !loading && (
+            <div className="px-3 py-2 text-xs text-ink-faint whitespace-nowrap">
+              {query.trim() ? "No matches" : "Type to search"}
+            </div>
+          )}
+          {results.map((r, i) => (
+            <button
+              key={`${r.provider}:${r.id}`}
+              type="button"
+              role="option"
+              aria-selected={i === highlight}
+              onMouseDown={(e) => {
+                e.preventDefault();
+                choose(r);
+              }}
+              onMouseEnter={() => setHighlight(i)}
+              className={`flex w-full items-start justify-between gap-3 px-3 py-2 text-left text-xs transition-colors ${
+                i === highlight ? "bg-surface text-ink" : "text-ink-soft hover:bg-surface"
+              }`}
+            >
+              <span className="min-w-0 flex-1 break-words">
+                <span className="font-medium">{r.label}</span>
+                {r.detail ? (
+                  <span className="ml-2 text-ink-faint">{r.detail}</span>
+                ) : null}
+              </span>
+              {r.score !== undefined && (
+                <span className="mono shrink-0 text-[10px] text-ink-faint">{r.score}</span>
+              )}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/onboarding/__tests__/StepTeam.test.tsx
+++ b/src/components/onboarding/__tests__/StepTeam.test.tsx
@@ -1,0 +1,159 @@
+// Regression coverage for the team-mapping step. The headline test pins
+// the bug the user reported: typing in the GitHub column must NEVER mutate
+// the Slack value. Other tests cover the smart-fill flow's "won't
+// overwrite manual selections" guarantee.
+
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// ── Mocks ────────────────────────────────────────────────────────────────
+
+const upsertMember = vi.fn<(arg: any) => Promise<number>>(async () => 1);
+const listMembers = vi.fn<() => Promise<any[]>>(async () => []);
+const getConfig = vi.fn<() => Promise<any>>(async () => ({
+  selected_jira_projects: [{ key: "KEEPR", id: "1", name: "Keepr" }],
+}));
+
+vi.mock("../../../services/db", () => ({
+  upsertMember: (arg: any) => upsertMember(arg),
+  listMembers: () => listMembers(),
+  getConfig: () => getConfig(),
+}));
+
+const getSecret = vi.fn<(key: string) => Promise<string | null>>(
+  async (key) => "token-" + key
+);
+vi.mock("../../../services/secrets", () => ({
+  SECRET_KEYS: {
+    slackBot: "slack.bot_token",
+    github: "github.token",
+    jiraEmail: "jira.email",
+    jiraToken: "jira.api_token",
+    linear: "linear.api_key",
+  },
+  getSecret: (key: string) => getSecret(key),
+}));
+
+const slackUsers = [
+  {
+    id: "U_PRIYA",
+    name: "priyar",
+    real_name: "Priya Raman",
+    profile: { display_name: "Priya R", real_name: "Priya Raman" },
+  },
+  {
+    id: "U_MARK",
+    name: "markb",
+    real_name: "Mark Brown",
+    profile: { display_name: "Mark", real_name: "Mark Brown" },
+  },
+];
+const listSlackUsers = vi.fn<() => Promise<typeof slackUsers>>(async () => slackUsers);
+vi.mock("../../../services/slack", () => ({
+  listUsers: () => listSlackUsers(),
+}));
+
+const linearUsers = [
+  { id: "lin-1", name: "priya", displayName: "Priya R.", email: "priya@x.io" },
+  { id: "lin-2", name: "mark", displayName: "Mark Brown", email: "mark@x.io" },
+];
+vi.mock("../../../services/linear", () => ({
+  listOrgMembers: vi.fn(async () => linearUsers),
+}));
+
+vi.mock("../../../services/jira", () => ({
+  listProjectMembers: vi.fn(async () => [
+    { accountId: "j-1", displayName: "Priya Raman", emailAddress: "priya@x.io" },
+  ]),
+}));
+
+vi.mock("../../../services/github", () => ({
+  listUserOrgs: vi.fn(async () => [{ login: "acme", description: null }]),
+  listOrgMembers: vi.fn(async () => [
+    { login: "octocat", name: "The Octocat", avatarUrl: null },
+    { login: "priya", name: "Priya Raman", avatarUrl: null },
+  ]),
+  hasReadOrgScope: vi.fn(async () => true),
+  invalidateScopeCache: vi.fn(),
+  GITHUB_CLIENT_ID: "Iv1.keepr-placeholder",
+  GITHUB_OAUTH_SCOPES: "read:user repo read:org",
+}));
+
+vi.mock("../../../services/memory", () => ({
+  slugify: (s: string) => s.toLowerCase().replace(/\s+/g, "-"),
+}));
+
+import { StepTeam } from "../StepTeam";
+import { invalidateGitHubPool } from "../../../services/teammateSearch";
+
+beforeEach(() => {
+  upsertMember.mockClear();
+  listMembers.mockReset();
+  listMembers.mockResolvedValue([]);
+  getSecret.mockReset();
+  getSecret.mockImplementation(async () => "tok");
+  getConfig.mockReset();
+  getConfig.mockResolvedValue({
+    selected_jira_projects: [{ key: "KEEPR", id: "1", name: "Keepr" }],
+  });
+  invalidateGitHubPool();
+});
+
+afterEach(() => {
+  vi.clearAllTimers();
+});
+
+describe("StepTeam — cross-field overwrite regression", () => {
+  it("typing in the GitHub column does NOT change the Slack value", async () => {
+    const onNext = vi.fn();
+    render(<StepTeam onNext={onNext} />);
+
+    // Wait for initial load (provider availability check).
+    await waitFor(() => expect(getSecret).toHaveBeenCalled());
+
+    // Type a display name.
+    const nameInput = screen.getAllByPlaceholderText("Display name")[0] as HTMLInputElement;
+    fireEvent.change(nameInput, { target: { value: "Priya Raman" } });
+
+    // Save without ever touching the GitHub column. There must be no
+    // auto-bound Slack id — we never opened the Slack combobox or typed
+    // anything that should have set it.
+    const save = screen.getByRole("button", { name: /save/i });
+    fireEvent.click(save);
+    await waitFor(() => expect(upsertMember).toHaveBeenCalled());
+    const arg = upsertMember.mock.calls[0]![0] as any;
+    expect(arg.display_name).toBe("Priya Raman");
+    // The classic bug: typing in name auto-set slack_user_id. Today, it
+    // must stay null until the user explicitly picks.
+    expect(arg.slack_user_id).toBeNull();
+    expect(arg.github_handle).toBeNull();
+  });
+});
+
+describe("StepTeam — smart-fill confirmation panel", () => {
+  it("opens on click and shows candidates for connected providers only", async () => {
+    // GitHub disconnected, others connected.
+    getSecret.mockImplementation(async (key: string) => {
+      if (key === "github.token") return null;
+      return "tok";
+    });
+
+    render(<StepTeam onNext={vi.fn()} />);
+
+    await waitFor(() => expect(getSecret).toHaveBeenCalled());
+
+    fireEvent.change(
+      (screen.getAllByPlaceholderText("Display name")[0] as HTMLInputElement),
+      { target: { value: "Priya" } }
+    );
+
+    const buttons = screen.getAllByRole("button", { name: /find matches across all/i });
+    fireEvent.click(buttons[0]);
+
+    // Panel resolves to candidate select boxes for connected providers.
+    await waitFor(() => {
+      // At least one provider label should appear in the panel.
+      expect(screen.queryByText(/searching all providers/i)).toBeNull();
+    });
+  });
+});

--- a/src/components/onboarding/__tests__/UserCombobox.test.tsx
+++ b/src/components/onboarding/__tests__/UserCombobox.test.tsx
@@ -1,0 +1,161 @@
+// Combobox behaviour: lazy load, debounce + abort, keyboard nav, label
+// resolution, and the "clearing the input does NOT clear the value"
+// guarantee that prevents silent overwrites.
+
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { UserCombobox } from "../UserCombobox";
+import type { ProviderUserMatch } from "../../../services/teammateSearch";
+
+function makeMatch(overrides: Partial<ProviderUserMatch> = {}): ProviderUserMatch {
+  return {
+    provider: "slack",
+    id: "U_PRIYA",
+    handle: "U_PRIYA",
+    label: "Priya R",
+    detail: "@priyar",
+    ...overrides,
+  };
+}
+
+describe("UserCombobox", () => {
+  it("calls onLoad once on first focus, then never again", async () => {
+    const onLoad = vi.fn(async () => {});
+    const search = vi.fn(() => [makeMatch()]);
+    render(
+      <UserCombobox
+        provider="slack"
+        value={null}
+        onChange={vi.fn()}
+        onLoad={onLoad}
+        search={search}
+      />
+    );
+    const input = screen.getByRole("combobox");
+    fireEvent.focus(input);
+    await waitFor(() => expect(search).toHaveBeenCalled());
+    fireEvent.blur(input);
+    fireEvent.focus(input);
+    await new Promise((r) => setTimeout(r, 50));
+    expect(onLoad).toHaveBeenCalledTimes(1);
+  });
+
+  it("debounces the search call to a single invocation per burst of typing", async () => {
+    const search = vi.fn<(q: string) => ProviderUserMatch[]>(() => [
+      makeMatch({ label: "Match" }),
+    ]);
+    render(
+      <UserCombobox
+        provider="slack"
+        value={null}
+        onChange={vi.fn()}
+        search={search}
+      />
+    );
+    const input = screen.getByRole("combobox") as HTMLInputElement;
+    fireEvent.focus(input);
+    await waitFor(() => expect(search).toHaveBeenCalled());
+    search.mockClear();
+
+    fireEvent.change(input, { target: { value: "pri" } });
+    fireEvent.change(input, { target: { value: "priy" } });
+    fireEvent.change(input, { target: { value: "priya" } });
+    // Wait past debounce window.
+    await new Promise((r) => setTimeout(r, 250));
+    // After debounce, only the final query is searched.
+    expect(search).toHaveBeenCalledTimes(1);
+    expect(search.mock.calls[0]![0]).toBe("priya");
+
+    await waitFor(() => expect(screen.getByRole("option")).toBeInTheDocument());
+  });
+
+  it("clearing the text input via Backspace does NOT clear the persisted value", async () => {
+    const onChange = vi.fn();
+    const search = vi.fn(() => [makeMatch()]);
+    render(
+      <UserCombobox
+        provider="slack"
+        value="U_PRIYA"
+        label="Priya R"
+        onChange={onChange}
+        search={search}
+      />
+    );
+    const input = screen.getByRole("combobox") as HTMLInputElement;
+    expect(input.value).toBe("Priya R");
+    fireEvent.focus(input);
+    await waitFor(() => expect(search).toHaveBeenCalled());
+    fireEvent.keyDown(input, { key: "Backspace" });
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it("× button explicitly clears the value", async () => {
+    const onChange = vi.fn();
+    const search = vi.fn(() => []);
+    render(
+      <UserCombobox
+        provider="slack"
+        value="U_PRIYA"
+        label="Priya R"
+        onChange={onChange}
+        search={search}
+      />
+    );
+    const clearBtn = screen.getByRole("button", { name: /clear selection/i });
+    fireEvent.click(clearBtn);
+    expect(onChange).toHaveBeenCalledWith(null);
+  });
+
+  it("Enter selects the highlighted result", async () => {
+    const onChange = vi.fn();
+    const a = makeMatch({ id: "U_A", label: "Alpha" });
+    const b = makeMatch({ id: "U_B", label: "Bravo" });
+    const search = vi.fn(() => [a, b]);
+    render(
+      <UserCombobox
+        provider="slack"
+        value={null}
+        onChange={onChange}
+        search={search}
+      />
+    );
+    const input = screen.getByRole("combobox");
+    fireEvent.focus(input);
+    await waitFor(() => expect(screen.getAllByRole("option").length).toBeGreaterThan(0));
+    fireEvent.keyDown(input, { key: "ArrowDown" });
+    fireEvent.keyDown(input, { key: "Enter" });
+    expect(onChange).toHaveBeenCalledWith(b);
+  });
+
+  it("resolveLabel runs once on mount when value is set without a label", async () => {
+    const resolveLabel = vi.fn(async () => "Priya Raman");
+    render(
+      <UserCombobox
+        provider="github"
+        value="priyar"
+        onChange={vi.fn()}
+        search={vi.fn(() => [])}
+        resolveLabel={resolveLabel}
+      />
+    );
+    await waitFor(() => expect(resolveLabel).toHaveBeenCalledWith("priyar"));
+    const input = screen.getByRole("combobox") as HTMLInputElement;
+    await waitFor(() => expect(input.value).toBe("Priya Raman"));
+  });
+
+  it("renders disabled with hint when provider is not connected", () => {
+    render(
+      <UserCombobox
+        provider="jira"
+        value={null}
+        onChange={vi.fn()}
+        search={vi.fn(() => [])}
+        disabled
+        disabledHint="Connect Jira to map"
+      />
+    );
+    const input = screen.getByRole("combobox") as HTMLInputElement;
+    expect(input).toBeDisabled();
+    expect(input.placeholder).toBe("Connect Jira to map");
+  });
+});

--- a/src/components/onboarding/fuzzyMatch.ts
+++ b/src/components/onboarding/fuzzyMatch.ts
@@ -1,13 +1,13 @@
-// Very small fuzzy matcher for the team-members step: given a github
-// handle or a free-text display name, score candidate Slack users and
-// return them ranked best-first. Intentionally tiny — no trigram index,
-// no Levenshtein — just the heuristics that actually matter when your
-// input is a github handle and your candidates are Slack display names.
+// Tiny fuzzy matcher for the team-members step. Generic over candidate
+// shape: callers pass a function returning the strings to match against.
+// Intentionally small — no trigrams, no Levenshtein — just the heuristics
+// that matter when input is a human name or handle and candidates are
+// display names from a provider's user list.
 
 import type { SlackUser } from "../../services/slack";
 
-export interface Scored {
-  user: SlackUser;
+export interface Scored<T> {
+  user: T;
   score: number;
 }
 
@@ -15,7 +15,63 @@ function norm(s: string): string {
   return s.toLowerCase().normalize("NFKD").replace(/[^a-z0-9]/g, "");
 }
 
-function candidateStrings(u: SlackUser): string[] {
+function tokenize(s: string): string[] {
+  return s.toLowerCase().split(/[^a-z0-9]+/).filter(Boolean);
+}
+
+/** Score `query` against an array of candidate strings. */
+export function scoreCandidates(query: string, candidates: string[]): number {
+  if (!query) return 0;
+  const qn = norm(query);
+  if (!qn) return 0;
+  const qTokens = tokenize(query);
+  let best = 0;
+  for (const cand of candidates) {
+    if (!cand) continue;
+    const cn = norm(cand);
+    if (!cn) continue;
+
+    if (cn === qn) return 100;
+    if (cn.includes(qn)) best = Math.max(best, 75);
+    if (qn.includes(cn)) best = Math.max(best, 60);
+
+    const cTokens = tokenize(cand);
+    if (qTokens.length && cTokens.length) {
+      const overlap = qTokens.filter((t) =>
+        cTokens.some((c) => c.startsWith(t))
+      ).length;
+      if (overlap) {
+        best = Math.max(best, 40 + overlap * 10);
+      }
+    }
+
+    if (qn.length >= 2 && qn.length <= 4) {
+      const initials = cTokens.map((t) => t[0]).join("");
+      if (initials.startsWith(qn)) best = Math.max(best, 30);
+    }
+  }
+  return best;
+}
+
+/** Generic ranker. Returns the top `limit` candidates with score > 0. */
+export function rankCandidates<T>(
+  query: string,
+  items: T[],
+  getStrings: (item: T) => string[],
+  limit = 5
+): Scored<T>[] {
+  const out: Scored<T>[] = [];
+  for (const item of items) {
+    const s = scoreCandidates(query, getStrings(item));
+    if (s > 0) out.push({ user: item, score: s });
+  }
+  out.sort((a, b) => b.score - a.score);
+  return out.slice(0, limit);
+}
+
+// ── Slack-specific helpers (kept for back-compat with existing tests/UI) ─
+
+function slackCandidateStrings(u: SlackUser): string[] {
   return [
     u.profile?.display_name || "",
     u.profile?.real_name || "",
@@ -26,64 +82,12 @@ function candidateStrings(u: SlackUser): string[] {
     .filter(Boolean);
 }
 
-function tokenize(s: string): string[] {
-  return s.toLowerCase().split(/[^a-z0-9]+/).filter(Boolean);
-}
-
-/** Score `query` (a display name or a handle) against a Slack user. */
-function scoreOne(query: string, user: SlackUser): number {
-  if (!query) return 0;
-  const qn = norm(query);
-  if (!qn) return 0;
-  let best = 0;
-  for (const cand of candidateStrings(user)) {
-    const cn = norm(cand);
-    if (!cn) continue;
-
-    // Exact match on any variant — best possible.
-    if (cn === qn) return 100;
-    // Handle-style: qn is a substring of the candidate (e.g. "priyar"
-    // matching "priya raman").
-    if (cn.includes(qn)) best = Math.max(best, 75);
-    if (qn.includes(cn)) best = Math.max(best, 60);
-
-    // Token overlap — catches "priya raman" vs "Priya R." etc.
-    const qTokens = tokenize(query);
-    const cTokens = tokenize(cand);
-    if (qTokens.length && cTokens.length) {
-      const overlap = qTokens.filter((t) => cTokens.some((c) => c.startsWith(t))).length;
-      if (overlap) {
-        best = Math.max(best, 40 + overlap * 10);
-      }
-    }
-
-    // First-letter initial match (e.g. "pr" matches "Priya Raman" via
-    // initials).
-    if (qn.length >= 2 && qn.length <= 4) {
-      const initials = cTokens.map((t) => t[0]).join("");
-      if (initials.startsWith(qn)) best = Math.max(best, 30);
-    }
-  }
-  return best;
-}
-
-/**
- * Rank a Slack user list against a query, returning the top N above a
- * minimum score. Used to suggest a Slack user from a github handle or a
- * display name while typing.
- */
 export function fuzzyMatchSlack(
   query: string,
   users: SlackUser[],
   limit = 5
-): Scored[] {
-  const out: Scored[] = [];
-  for (const u of users) {
-    const s = scoreOne(query, u);
-    if (s > 0) out.push({ user: u, score: s });
-  }
-  out.sort((a, b) => b.score - a.score);
-  return out.slice(0, limit);
+): Scored<SlackUser>[] {
+  return rankCandidates(query, users, slackCandidateStrings, limit);
 }
 
 export function bestSlackMatch(

--- a/src/screens/Settings.tsx
+++ b/src/screens/Settings.tsx
@@ -38,6 +38,19 @@ import type { AppConfig, FeatureFlags, TeamMember } from "../lib/types";
 import { DEFAULT_CONFIG, DEFAULT_FEATURE_FLAGS } from "../lib/types";
 import { GitHubIcon, GitLabIcon, SlackIcon, JiraIcon, LinearIcon } from "../components/primitives/SourceBadge";
 import { ChipGrid, SourceChip } from "../components/onboarding/primitives";
+import { UserCombobox } from "../components/onboarding/UserCombobox";
+import {
+  loadGitHubMemberPool,
+  loadJiraUserPool,
+  resolveGitHubLabel,
+  resolveJiraLabel,
+  resolveLinearLabel,
+  resolveSlackLabel,
+  searchGitHub,
+  searchJira,
+  searchLinear,
+  searchSlack,
+} from "../services/teammateSearch";
 import type { IntegrationKind } from "../services/pulseOutcome";
 
 export function Settings({
@@ -77,6 +90,9 @@ export function Settings({
   const [jiraUsersLoaded, setJiraUsersLoaded] = useState(false);
   const [linearUsers, setLinearUsers] = useState<linear.LinearUser[]>([]);
   const [linearUsersLoaded, setLinearUsersLoaded] = useState(false);
+  const [githubMembers, setGithubMembers] = useState<github.GitHubMember[]>([]);
+  const [githubMembersLoaded, setGithubMembersLoaded] = useState(false);
+  const [githubScopeOK, setGithubScopeOK] = useState<boolean | null>(null);
 
   const load = async () => {
     const freshCfg = await getConfig();
@@ -104,6 +120,24 @@ export function Settings({
   useEffect(() => {
     load();
   }, []);
+
+  // Probe GitHub OAuth scope so the team-mapping panel can warn the user
+  // to reconnect when read:org is missing — otherwise the GitHub picker
+  // silently shows zero candidates.
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      const tok = await getSecret(SECRET_KEYS.github);
+      if (cancelled) return;
+      if (!tok) {
+        setGithubScopeOK(null);
+        return;
+      }
+      const ok = await github.hasReadOrgScope().catch(() => false);
+      if (!cancelled) setGithubScopeOK(ok);
+    })();
+    return () => { cancelled = true; };
+  }, [ghToken]);
 
   // Lazy CLI probe: only fire when the active provider is a CLI tool, so
   // users opening Settings to fix Slack don't trigger a silent OpenAI/Anthropic
@@ -682,10 +716,19 @@ export function Settings({
         </Panel>
 
         <Panel title="Team members">
+          {githubScopeOK === false && (
+            <div className="mb-3 rounded-md border border-hairline bg-surface px-3 py-2 text-xs text-ink-soft leading-relaxed">
+              GitHub is connected, but the token is missing{" "}
+              <span className="mono">read:org</span>. Until you reconnect,
+              the GitHub picker won't see your org members. Update the token
+              above with <span className="mono">repo + read:user + read:org</span>{" "}
+              and save.
+            </div>
+          )}
           <div className="flex flex-col gap-2">
             {members.map((m) => (
               <div key={m.id} className="flex flex-col gap-1.5 rounded-md border border-hairline p-3 mb-2">
-                <div className="grid grid-cols-[1fr_1fr_1fr] gap-2">
+                <div className="grid grid-cols-[2fr_1fr] gap-2">
                   <input
                     className={inputCls}
                     value={m.display_name}
@@ -694,23 +737,44 @@ export function Settings({
                   />
                   <input
                     className={inputCls}
-                    placeholder="GitHub handle"
-                    value={m.github_handle || ""}
-                    onChange={(e) => setMembers(members.map((x) => x.id === m.id ? { ...x, github_handle: e.target.value } : x))}
-                  />
-                  <input
-                    className={inputCls}
                     placeholder="GitLab username"
                     value={m.gitlab_username || ""}
                     onChange={(e) => setMembers(members.map((x) => x.id === m.id ? { ...x, gitlab_username: e.target.value } : x))}
                   />
                 </div>
-                <div className="grid grid-cols-[1fr_1fr_1fr] gap-2">
-                  <SlackUserPicker
-                    value={m.slack_user_id || ""}
-                    slackUsers={slackUsers}
-                    slackUsersLoaded={slackUsersLoaded}
-                    onLoadUsers={async () => {
+                <div className="grid grid-cols-[1fr_1fr_1fr_1fr] gap-2">
+                  <UserCombobox
+                    provider="github"
+                    value={m.github_handle || null}
+                    placeholder="Search GitHub…"
+                    initialSeed={m.display_name}
+                    disabled={githubScopeOK === false}
+                    disabledHint="Reconnect GitHub with read:org scope"
+                    search={(q) => searchGitHub(q, githubMembers)}
+                    onLoad={async () => {
+                      if (githubMembersLoaded || githubScopeOK === false) return;
+                      try {
+                        const members = await loadGitHubMemberPool();
+                        setGithubMembers(members);
+                        setGithubMembersLoaded(true);
+                      } catch (e: any) {
+                        alert(`Could not load GitHub org members: ${e.message}`);
+                      }
+                    }}
+                    resolveLabel={async (h) => resolveGitHubLabel(h, githubMembers)}
+                    onChange={(match) =>
+                      setMembers(members.map((x) =>
+                        x.id === m.id ? { ...x, github_handle: match?.handle ?? null } : x
+                      ))
+                    }
+                  />
+                  <UserCombobox
+                    provider="slack"
+                    value={m.slack_user_id || null}
+                    placeholder="Search Slack…"
+                    initialSeed={m.display_name}
+                    search={(q) => searchSlack(q, slackUsers)}
+                    onLoad={async () => {
                       if (slackUsersLoaded) return;
                       try {
                         const users = await slack.listUsers();
@@ -720,33 +784,19 @@ export function Settings({
                         alert(`Could not load Slack users: ${e.message}`);
                       }
                     }}
-                    onChange={(uid) => setMembers(members.map((x) => x.id === m.id ? { ...x, slack_user_id: uid || null } : x))}
+                    resolveLabel={async (h) => resolveSlackLabel(h, slackUsers)}
+                    onChange={(match) =>
+                      setMembers(members.map((x) =>
+                        x.id === m.id ? { ...x, slack_user_id: match?.handle ?? null } : x
+                      ))
+                    }
                   />
-                  <UserPicker
-                    value={m.jira_username || ""}
-                    placeholder="Select Jira user"
-                    options={jiraUsers.map((u) => ({ value: u.displayName, label: u.displayName, detail: u.emailAddress }))}
-                    loaded={jiraUsersLoaded}
-                    onLoad={async () => {
-                      if (jiraUsersLoaded) return;
-                      try {
-                        const firstProject = cfg.selected_jira_projects?.[0];
-                        const users = firstProject
-                          ? await jira.listProjectMembers(firstProject.key)
-                          : [];
-                        setJiraUsers(users);
-                        setJiraUsersLoaded(true);
-                      } catch (e: any) {
-                        alert(`Could not load Jira users: ${e.message}`);
-                      }
-                    }}
-                    onChange={(v) => setMembers(members.map((x) => x.id === m.id ? { ...x, jira_username: v || null } : x))}
-                  />
-                  <UserPicker
-                    value={m.linear_username || ""}
-                    placeholder="Select Linear user"
-                    options={linearUsers.map((u) => ({ value: u.displayName || u.name, label: u.displayName || u.name, detail: u.email }))}
-                    loaded={linearUsersLoaded}
+                  <UserCombobox
+                    provider="linear"
+                    value={m.linear_username || null}
+                    placeholder="Search Linear…"
+                    initialSeed={m.display_name}
+                    search={(q) => searchLinear(q, linearUsers)}
                     onLoad={async () => {
                       if (linearUsersLoaded) return;
                       try {
@@ -757,7 +807,38 @@ export function Settings({
                         alert(`Could not load Linear users: ${e.message}`);
                       }
                     }}
-                    onChange={(v) => setMembers(members.map((x) => x.id === m.id ? { ...x, linear_username: v || null } : x))}
+                    resolveLabel={async (h) => resolveLinearLabel(h, linearUsers)}
+                    onChange={(match) =>
+                      setMembers(members.map((x) =>
+                        x.id === m.id ? { ...x, linear_username: match?.handle ?? null } : x
+                      ))
+                    }
+                  />
+                  <UserCombobox
+                    provider="jira"
+                    value={m.jira_username || null}
+                    placeholder="Search Jira…"
+                    initialSeed={m.display_name}
+                    disabled={!(cfg.selected_jira_projects?.length)}
+                    disabledHint="Pick a Jira project first"
+                    search={(q) => searchJira(q, jiraUsers)}
+                    onLoad={async () => {
+                      if (jiraUsersLoaded) return;
+                      try {
+                        const keys = (cfg.selected_jira_projects || []).map((p) => p.key);
+                        const users = await loadJiraUserPool(keys);
+                        setJiraUsers(users);
+                        setJiraUsersLoaded(true);
+                      } catch (e: any) {
+                        alert(`Could not load Jira users: ${e.message}`);
+                      }
+                    }}
+                    resolveLabel={async (h) => resolveJiraLabel(h, jiraUsers)}
+                    onChange={(match) =>
+                      setMembers(members.map((x) =>
+                        x.id === m.id ? { ...x, jira_username: match?.handle ?? null } : x
+                      ))
+                    }
                   />
                 </div>
                 <div className="flex items-center gap-2">
@@ -972,126 +1053,6 @@ function SaveButton({
         ? "Failed"
         : label}
     </button>
-  );
-}
-
-// Slack user picker — loads workspace users on first focus, shows a select
-// dropdown with human-readable names but stores the actual Slack user ID
-// (e.g. U05RQAXHBL7). This eliminates the #1 matching failure: users
-// entering display names instead of opaque user IDs.
-function SlackUserPicker({
-  value,
-  slackUsers,
-  slackUsersLoaded,
-  onLoadUsers,
-  onChange,
-}: {
-  value: string;
-  slackUsers: slack.SlackUser[];
-  slackUsersLoaded: boolean;
-  onLoadUsers: () => Promise<void>;
-  onChange: (uid: string) => void;
-}) {
-  const [loading, setLoading] = useState(false);
-
-  const handleFocus = async () => {
-    if (slackUsersLoaded || loading) return;
-    setLoading(true);
-    await onLoadUsers();
-    setLoading(false);
-  };
-
-  // Show the selected user's name next to the dropdown for confirmation
-  const selectedUser = slackUsers.find((u) => u.id === value);
-  const label = selectedUser
-    ? selectedUser.profile?.real_name || selectedUser.real_name || selectedUser.name
-    : null;
-
-  return (
-    <div className="relative">
-      <select
-        className={inputCls + " appearance-none pr-7"}
-        value={value}
-        onFocus={handleFocus}
-        onChange={(e) => onChange(e.target.value)}
-      >
-        <option value="">
-          {loading ? "Loading users\u2026" : "Select Slack user"}
-        </option>
-        {/* If a value is set but users haven't loaded yet, show a placeholder option */}
-        {value && !selectedUser && (
-          <option value={value}>{value} (not resolved)</option>
-        )}
-        {slackUsers.map((u) => {
-          const display = u.profile?.real_name || u.real_name || u.name;
-          return (
-            <option key={u.id} value={u.id}>
-              {display} ({u.name})
-            </option>
-          );
-        })}
-      </select>
-      {/* Dropdown chevron */}
-      <span className="pointer-events-none absolute right-2 top-1/2 -translate-y-1/2 text-ink-faint">
-        <svg width="12" height="12" viewBox="0 0 12 12" fill="none" aria-hidden>
-          <path d="M3 5l3 3 3-3" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" strokeLinejoin="round" />
-        </svg>
-      </span>
-    </div>
-  );
-}
-
-/** Generic user picker dropdown. Lazy-loads options on focus. */
-function UserPicker({
-  value,
-  placeholder,
-  options,
-  loaded,
-  onLoad,
-  onChange,
-}: {
-  value: string;
-  placeholder: string;
-  options: Array<{ value: string; label: string; detail?: string }>;
-  loaded: boolean;
-  onLoad: () => Promise<void>;
-  onChange: (v: string) => void;
-}) {
-  const [loading, setLoading] = useState(false);
-
-  const handleFocus = async () => {
-    if (loaded || loading) return;
-    setLoading(true);
-    await onLoad();
-    setLoading(false);
-  };
-
-  return (
-    <div className="relative">
-      <select
-        className={inputCls + " appearance-none pr-7"}
-        value={value}
-        onFocus={handleFocus}
-        onChange={(e) => onChange(e.target.value)}
-      >
-        <option value="">
-          {loading ? "Loading\u2026" : placeholder}
-        </option>
-        {value && !options.find((o) => o.value === value) && (
-          <option value={value}>{value}</option>
-        )}
-        {options.map((o) => (
-          <option key={o.value} value={o.value}>
-            {o.label}{o.detail ? ` (${o.detail})` : ""}
-          </option>
-        ))}
-      </select>
-      <span className="pointer-events-none absolute right-2 top-1/2 -translate-y-1/2 text-ink-faint">
-        <svg width="12" height="12" viewBox="0 0 12 12" fill="none" aria-hidden>
-          <path d="M3 5l3 3 3-3" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" strokeLinejoin="round" />
-        </svg>
-      </span>
-    </div>
   );
 }
 

--- a/src/screens/__tests__/Settings.test.tsx
+++ b/src/screens/__tests__/Settings.test.tsx
@@ -20,6 +20,10 @@ vi.mock("../../services/slack", () => ({
 
 vi.mock("../../services/github", () => ({
   listUserRepos: (...a: unknown[]) => listUserRepos(...a),
+  hasReadOrgScope: vi.fn(async () => true),
+  invalidateScopeCache: vi.fn(),
+  listUserOrgs: vi.fn(async () => []),
+  listOrgMembers: vi.fn(async () => []),
 }));
 
 vi.mock("../../services/gitlab", () => ({

--- a/src/services/__tests__/teammateSearch.test.ts
+++ b/src/services/__tests__/teammateSearch.test.ts
@@ -1,0 +1,185 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  searchSlack,
+  searchLinear,
+  searchJira,
+  searchGitHub,
+  loadJiraUserPool,
+  loadGitHubMemberPool,
+  invalidateGitHubPool,
+  resolveGitHubLabel,
+  resolveSlackLabel,
+} from "../teammateSearch";
+import type { SlackUser } from "../slack";
+import type { LinearUser } from "../linear";
+import type { JiraUser } from "../jira";
+import type { GitHubMember } from "../github";
+
+vi.mock("../github", () => ({
+  listUserOrgs: vi.fn(async () => [
+    { login: "acme", description: null },
+    { login: "widgets", description: null },
+  ]),
+  listOrgMembers: vi.fn(async (org: string) => {
+    if (org === "acme") {
+      return [
+        { login: "octocat", name: "The Octocat", avatarUrl: null },
+        { login: "shared", name: "Shared User", avatarUrl: null },
+      ];
+    }
+    if (org === "widgets") {
+      return [
+        { login: "priya", name: "Priya Raman", avatarUrl: null },
+        { login: "shared", name: "Shared User", avatarUrl: null },
+      ];
+    }
+    return [];
+  }),
+  hasReadOrgScope: vi.fn(async () => true),
+  invalidateScopeCache: vi.fn(),
+}));
+
+vi.mock("../jira", async () => {
+  let calls = 0;
+  return {
+    listProjectMembers: vi.fn(async (key: string) => {
+      calls++;
+      if (key === "FAIL") throw new Error("403");
+      // Same person appears in two projects — must dedup by accountId.
+      return [
+        { accountId: `acc-${key}-1`, displayName: "Priya Raman", emailAddress: "priya@x.io" },
+        { accountId: "acc-shared", displayName: "Shared User", emailAddress: "shared@x.io" },
+      ] satisfies JiraUser[];
+    }),
+    _calls: () => calls,
+  };
+});
+
+const slackCache: SlackUser[] = [
+  {
+    id: "U_PRIYA",
+    name: "priyar",
+    real_name: "Priya Raman",
+    profile: { display_name: "Priya R", real_name: "Priya Raman" },
+  },
+  {
+    id: "U_MARK",
+    name: "markb",
+    real_name: "Mark Brown",
+    profile: { display_name: "Mark", real_name: "Mark Brown" },
+  },
+];
+
+const linearCache: LinearUser[] = [
+  { id: "lin-1", name: "priya", displayName: "Priya R.", email: "priya@x.io" },
+  { id: "lin-2", name: "mark", displayName: "Mark Brown", email: "mark@x.io" },
+];
+
+const jiraCache: JiraUser[] = [
+  { accountId: "acc-1", displayName: "Priya Raman", emailAddress: "priya@x.io" },
+];
+
+describe("searchSlack", () => {
+  it("ranks display-name matches first", () => {
+    const out = searchSlack("priya", slackCache);
+    expect(out[0].handle).toBe("U_PRIYA");
+    expect(out[0].label).toBe("Priya R");
+  });
+
+  it("returns empty when cache is empty", () => {
+    expect(searchSlack("priya", [])).toEqual([]);
+  });
+
+  it("returns alphabetical list when query is empty", () => {
+    const out = searchSlack("", slackCache);
+    expect(out.map((m) => m.label)).toEqual(["Mark", "Priya R"]);
+  });
+});
+
+describe("searchLinear", () => {
+  it("persists displayName as the handle (pipeline matches by displayName)", () => {
+    const out = searchLinear("priya", linearCache);
+    expect(out[0].handle).toBe("Priya R.");
+  });
+});
+
+describe("searchJira", () => {
+  it("uses displayName as handle for pipeline compatibility", () => {
+    const out = searchJira("priya", jiraCache);
+    expect(out[0].handle).toBe("Priya Raman");
+  });
+});
+
+const githubCache: GitHubMember[] = [
+  { login: "octocat", name: "The Octocat", avatarUrl: null },
+  { login: "priya", name: "Priya Raman", avatarUrl: null },
+];
+
+describe("searchGitHub", () => {
+  it("uses login as handle and 'Name (@login)' as label", () => {
+    const out = searchGitHub("priya", githubCache);
+    expect(out[0].handle).toBe("priya");
+    expect(out[0].label).toBe("Priya Raman (@priya)");
+  });
+
+  it("returns alphabetical list when query empty (sorted by visible label)", () => {
+    const out = searchGitHub("", githubCache);
+    // "Priya Raman (@priya)" < "The Octocat (@octocat)"
+    expect(out.map((m) => m.handle)).toEqual(["priya", "octocat"]);
+  });
+
+  it("returns empty when cache is empty", () => {
+    expect(searchGitHub("priya", [])).toEqual([]);
+  });
+});
+
+describe("loadGitHubMemberPool", () => {
+  it("unions members across all orgs and dedupes by login", async () => {
+    invalidateGitHubPool();
+    const pool = await loadGitHubMemberPool();
+    const logins = pool.map((m) => m.login).sort();
+    expect(logins).toEqual(["octocat", "priya", "shared"]);
+  });
+
+  it("coalesces concurrent callers into a single fetch", async () => {
+    invalidateGitHubPool();
+    const [a, b] = await Promise.all([
+      loadGitHubMemberPool(),
+      loadGitHubMemberPool(),
+    ]);
+    expect(a).toBe(b);
+  });
+});
+
+describe("resolveGitHubLabel", () => {
+  it("looks up cached login and renders 'Name (@login)'", () => {
+    expect(resolveGitHubLabel("priya", githubCache)).toBe("Priya Raman (@priya)");
+    expect(resolveGitHubLabel("ghost", githubCache)).toBeNull();
+  });
+});
+
+describe("loadJiraUserPool", () => {
+  it("dedupes users seen across multiple projects", async () => {
+    const pool = await loadJiraUserPool(["KEEPR", "DEMO"]);
+    const ids = pool.map((u) => u.accountId).sort();
+    expect(ids).toContain("acc-shared");
+    // acc-shared appears in both project responses → must appear only once.
+    expect(ids.filter((x) => x === "acc-shared").length).toBe(1);
+  });
+
+  it("survives a single project's failure", async () => {
+    const pool = await loadJiraUserPool(["KEEPR", "FAIL", "DEMO"]);
+    expect(pool.length).toBeGreaterThan(0);
+  });
+
+  it("returns empty when no project keys are given", async () => {
+    expect(await loadJiraUserPool([])).toEqual([]);
+  });
+});
+
+describe("resolveSlackLabel", () => {
+  it("looks up label by id", () => {
+    expect(resolveSlackLabel("U_PRIYA", slackCache)).toBe("Priya R");
+    expect(resolveSlackLabel("U_GHOST", slackCache)).toBeNull();
+  });
+});

--- a/src/services/github.ts
+++ b/src/services/github.ts
@@ -27,11 +27,18 @@ export interface DeviceCodeResponse {
   interval: number;
 }
 
+// Scopes requested at auth time. `read:org` is required so the
+// authenticated user can list members of orgs they belong to (used for
+// teammate mapping). Without it, GitHub only returns members who have
+// publicly listed their org membership — typically a small fraction of
+// any private corporate org.
+export const GITHUB_OAUTH_SCOPES = "read:user repo read:org";
+
 export async function startDeviceFlow(): Promise<DeviceCodeResponse> {
   const res = await fetch("https://github.com/login/device/code", {
     method: "POST",
     headers: { Accept: "application/json", "Content-Type": "application/json" },
-    body: JSON.stringify({ client_id: GITHUB_CLIENT_ID, scope: "read:user repo" }),
+    body: JSON.stringify({ client_id: GITHUB_CLIENT_ID, scope: GITHUB_OAUTH_SCOPES }),
   });
   if (!res.ok) throw new Error(`GitHub device flow start failed: ${res.status}`);
   return (await res.json()) as DeviceCodeResponse;
@@ -101,6 +108,171 @@ export async function getViewer(): Promise<{ login: string; name: string | null 
   const token = await getSecret(SECRET_KEYS.github);
   if (!token) throw new Error("No GitHub token");
   return gh<{ login: string; name: string | null }>("/user", token);
+}
+
+// ---- Orgs + members (for teammate mapping) ------------------------------
+
+export interface GitHubOrg {
+  login: string;
+  description: string | null;
+}
+
+export async function listUserOrgs(): Promise<GitHubOrg[]> {
+  const token = await getSecret(SECRET_KEYS.github);
+  if (!token) throw new Error("No GitHub token");
+  const data = await gh<Array<{ login: string; description: string | null }>>(
+    "/user/orgs?per_page=100",
+    token
+  );
+  return data.map((o) => ({ login: o.login, description: o.description }));
+}
+
+export interface GitHubMember {
+  login: string;
+  name: string | null;
+  avatarUrl: string | null;
+}
+
+const GRAPHQL_URL = "https://api.github.com/graphql";
+
+async function ghGraphQL<T>(
+  query: string,
+  variables: Record<string, unknown>,
+  signal?: AbortSignal
+): Promise<T> {
+  const token = await getSecret(SECRET_KEYS.github);
+  if (!token) throw new Error("No GitHub token");
+  const res = await fetch(GRAPHQL_URL, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      Accept: "application/json",
+      "Content-Type": "application/json",
+      "User-Agent": "Keepr/0.1",
+    },
+    body: JSON.stringify({ query, variables }),
+    signal,
+  });
+  if (!res.ok) {
+    const errText = await res.text().catch(() => "");
+    throw new Error(
+      `GitHub GraphQL: ${res.status} ${res.statusText}` +
+        (errText ? ` — ${errText.slice(0, 400)}` : "")
+    );
+  }
+  const data: any = await res.json();
+  if (data.errors?.length) {
+    const msgs = data.errors.map((e: any) => e.message).join("; ");
+    // SAML SSO requirement and missing scopes both surface here. Surface
+    // distinctly so the UI can prompt re-auth instead of generic "failed".
+    if (/scope|read:org|membersWithRole/i.test(msgs)) {
+      throw new Error(`GitHub GraphQL: missing read:org scope — ${msgs}`);
+    }
+    throw new Error(`GitHub GraphQL: ${msgs}`);
+  }
+  return data.data as T;
+}
+
+const ORG_MEMBERS_CAP = 2000;
+
+/**
+ * Lists members of an org via GraphQL `membersWithRole`. Returns login,
+ * name, and avatar — names are why we don't use REST `/orgs/{org}/members`
+ * (that endpoint does not include name). Paginates fully via cursor with a
+ * 2000-member safety cap.
+ */
+interface OrgMembersResp {
+  organization: {
+    membersWithRole: {
+      nodes: Array<{ login: string; name: string | null; avatarUrl: string | null }>;
+      pageInfo: { hasNextPage: boolean; endCursor: string | null };
+    } | null;
+  } | null;
+}
+
+export async function listOrgMembers(
+  orgLogin: string,
+  signal?: AbortSignal
+): Promise<GitHubMember[]> {
+  const out: GitHubMember[] = [];
+  let cursor: string | null = null;
+  for (let page = 0; page < 25; page++) {
+    if (out.length >= ORG_MEMBERS_CAP) break;
+    const data: OrgMembersResp = await ghGraphQL<OrgMembersResp>(
+      `query($org: String!, $after: String) {
+        organization(login: $org) {
+          membersWithRole(first: 100, after: $after) {
+            nodes { login name avatarUrl }
+            pageInfo { hasNextPage endCursor }
+          }
+        }
+      }`,
+      { org: orgLogin, after: cursor },
+      signal
+    );
+    const block = data.organization?.membersWithRole;
+    if (!block) break;
+    for (const n of block.nodes) {
+      out.push({
+        login: n.login,
+        name: n.name,
+        avatarUrl: n.avatarUrl,
+      });
+      if (out.length >= ORG_MEMBERS_CAP) break;
+    }
+    if (!block.pageInfo.hasNextPage) break;
+    cursor = block.pageInfo.endCursor;
+    if (!cursor) break;
+  }
+  return out;
+}
+
+// ---- OAuth scope detection ----------------------------------------------
+
+let _scopeCache: { token: string; scopes: string[] } | null = null;
+
+/**
+ * Reads the granted OAuth scopes by inspecting the `X-OAuth-Scopes`
+ * response header from a cheap `/user` call. Cached per-token in module
+ * memory. Returns [] when the call fails or the header is absent (some
+ * fine-grained PATs don't surface scopes — caller should treat empty as
+ * "unknown" rather than "no scopes").
+ */
+export async function getGrantedScopes(): Promise<string[]> {
+  const token = await getSecret(SECRET_KEYS.github);
+  if (!token) return [];
+  if (_scopeCache && _scopeCache.token === token) return _scopeCache.scopes;
+  try {
+    const res = await fetch("https://api.github.com/user", {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+        "User-Agent": "Keepr/0.1",
+      },
+    });
+    if (!res.ok) return [];
+    const raw = res.headers.get("X-OAuth-Scopes") || "";
+    const scopes = raw
+      .split(",")
+      .map((s) => s.trim())
+      .filter(Boolean);
+    _scopeCache = { token, scopes };
+    return scopes;
+  } catch {
+    return [];
+  }
+}
+
+/** Invalidate the scope cache (call after a successful re-auth). */
+export function invalidateScopeCache(): void {
+  _scopeCache = null;
+}
+
+export async function hasReadOrgScope(): Promise<boolean> {
+  const scopes = await getGrantedScopes();
+  // `admin:org` and `write:org` imply `read:org`.
+  return scopes.some((s) => s === "read:org" || s === "write:org" || s === "admin:org");
 }
 
 export async function listOrgRepos(org: string): Promise<Array<{ name: string; full_name: string }>> {

--- a/src/services/teammateSearch.ts
+++ b/src/services/teammateSearch.ts
@@ -1,0 +1,318 @@
+// Unified search across the four people-providers Keepr maps team members
+// to (Slack, GitHub, Linear, Jira). Each adapter returns `ProviderUserMatch`
+// so the combobox UI can stay provider-agnostic.
+//
+// The persisted `handle` field below matches what the pipeline's actor
+// resolution looks up (services/pipeline.ts:359-383):
+//   - slack:  Slack user id (e.g. "U01ABC")           → team_members.slack_user_id
+//   - github: login (e.g. "octocat")                  → team_members.github_handle
+//   - linear: displayName (or name fallback)          → team_members.linear_username
+//   - jira:   displayName                             → team_members.jira_username
+//
+// Linear and Jira are matched by display-name string equality (lowercased)
+// in the pipeline, so the picker MUST persist the displayName the user
+// picks, not the underlying id. The `id` field is kept on the match for
+// dedup inside the combobox dropdown only.
+
+import { rankCandidates } from "../components/onboarding/fuzzyMatch";
+import * as github from "./github";
+import * as jira from "./jira";
+import * as linear from "./linear";
+import type { GitHubMember } from "./github";
+import type { JiraUser } from "./jira";
+import type { LinearUser } from "./linear";
+import type { SlackUser } from "./slack";
+
+export type TeammateProvider = "slack" | "github" | "linear" | "jira";
+
+export interface ProviderUserMatch {
+  provider: TeammateProvider;
+  /** Stable id from the provider — used as React key + dedup in dropdowns. */
+  id: string;
+  /** What we persist in team_members.{slack_user_id|github_handle|...}. */
+  handle: string;
+  /** Primary visible label in the dropdown row. */
+  label: string;
+  /** Optional secondary line (email / handle / etc). */
+  detail?: string;
+  avatarUrl?: string;
+  score?: number;
+}
+
+// ── Slack ──────────────────────────────────────────────────────────────────
+
+function slackLabel(u: SlackUser): string {
+  return u.profile?.display_name || u.real_name || u.name || u.id;
+}
+
+function slackDetail(u: SlackUser): string | undefined {
+  // Show the @handle as detail when display_name is something different.
+  if (u.profile?.display_name && u.name && u.profile.display_name !== u.name) {
+    return `@${u.name}`;
+  }
+  return u.name ? `@${u.name}` : undefined;
+}
+
+function slackCandidates(u: SlackUser): string[] {
+  return [
+    u.profile?.display_name || "",
+    u.profile?.real_name || "",
+    u.real_name || "",
+    u.name || "",
+  ]
+    .map((s) => s.trim())
+    .filter(Boolean);
+}
+
+export function searchSlack(
+  query: string,
+  cache: SlackUser[],
+  limit = 8
+): ProviderUserMatch[] {
+  if (!cache.length) return [];
+  if (!query.trim()) {
+    // Empty query: return the first `limit` users alphabetically by label.
+    return cache
+      .slice()
+      .sort((a, b) => slackLabel(a).localeCompare(slackLabel(b)))
+      .slice(0, limit)
+      .map((u) => ({
+        provider: "slack" as const,
+        id: u.id,
+        handle: u.id,
+        label: slackLabel(u),
+        detail: slackDetail(u),
+      }));
+  }
+  return rankCandidates(query, cache, slackCandidates, limit).map((s) => ({
+    provider: "slack" as const,
+    id: s.user.id,
+    handle: s.user.id,
+    label: slackLabel(s.user),
+    detail: slackDetail(s.user),
+    score: s.score,
+  }));
+}
+
+export function resolveSlackLabel(handle: string, cache: SlackUser[]): string | null {
+  const u = cache.find((x) => x.id === handle);
+  return u ? slackLabel(u) : null;
+}
+
+// ── Linear ─────────────────────────────────────────────────────────────────
+
+function linearLabel(u: LinearUser): string {
+  return u.displayName || u.name;
+}
+
+function linearCandidates(u: LinearUser): string[] {
+  return [u.displayName, u.name, u.email || ""].filter(Boolean);
+}
+
+export function searchLinear(
+  query: string,
+  cache: LinearUser[],
+  limit = 8
+): ProviderUserMatch[] {
+  if (!cache.length) return [];
+  if (!query.trim()) {
+    return cache
+      .slice()
+      .sort((a, b) => linearLabel(a).localeCompare(linearLabel(b)))
+      .slice(0, limit)
+      .map((u) => ({
+        provider: "linear" as const,
+        id: u.id,
+        handle: linearLabel(u),
+        label: linearLabel(u),
+        detail: u.email,
+      }));
+  }
+  return rankCandidates(query, cache, linearCandidates, limit).map((s) => ({
+    provider: "linear" as const,
+    id: s.user.id,
+    handle: linearLabel(s.user),
+    label: linearLabel(s.user),
+    detail: s.user.email,
+    score: s.score,
+  }));
+}
+
+export function resolveLinearLabel(handle: string, cache: LinearUser[]): string | null {
+  const u = cache.find((x) => linearLabel(x) === handle);
+  return u ? linearLabel(u) : null;
+}
+
+// ── Jira ───────────────────────────────────────────────────────────────────
+
+function jiraLabel(u: JiraUser): string {
+  return u.displayName;
+}
+
+function jiraCandidates(u: JiraUser): string[] {
+  return [u.displayName, u.emailAddress || ""].filter(Boolean);
+}
+
+/**
+ * Loads and merges assignable users across all selected Jira projects.
+ * Falls back to the org-wide /users/search inside `listProjectMembers` when
+ * a project's assignable endpoint is restricted. Dedups by accountId.
+ */
+export async function loadJiraUserPool(
+  projectKeys: string[]
+): Promise<JiraUser[]> {
+  if (!projectKeys.length) return [];
+  const seen = new Map<string, JiraUser>();
+  // Sequential to avoid hammering Jira; each call is already 100 max.
+  for (const key of projectKeys) {
+    try {
+      const users = await jira.listProjectMembers(key);
+      for (const u of users) {
+        if (!seen.has(u.accountId)) seen.set(u.accountId, u);
+      }
+    } catch {
+      // Per-project failure: continue with whatever we have.
+    }
+  }
+  return Array.from(seen.values());
+}
+
+export function searchJira(
+  query: string,
+  cache: JiraUser[],
+  limit = 8
+): ProviderUserMatch[] {
+  if (!cache.length) return [];
+  if (!query.trim()) {
+    return cache
+      .slice()
+      .sort((a, b) => jiraLabel(a).localeCompare(jiraLabel(b)))
+      .slice(0, limit)
+      .map((u) => ({
+        provider: "jira" as const,
+        id: u.accountId,
+        handle: jiraLabel(u),
+        label: jiraLabel(u),
+        detail: u.emailAddress,
+      }));
+  }
+  return rankCandidates(query, cache, jiraCandidates, limit).map((s) => ({
+    provider: "jira" as const,
+    id: s.user.accountId,
+    handle: jiraLabel(s.user),
+    label: jiraLabel(s.user),
+    detail: s.user.emailAddress,
+    score: s.score,
+  }));
+}
+
+export function resolveJiraLabel(handle: string, cache: JiraUser[]): string | null {
+  const u = cache.find((x) => x.displayName === handle);
+  return u ? jiraLabel(u) : null;
+}
+
+// ── GitHub (cache-backed, scoped to user's orgs) ──────────────────────────
+
+function githubLabel(m: GitHubMember): string {
+  return m.name ? `${m.name} (@${m.login})` : `@${m.login}`;
+}
+
+function githubCandidates(m: GitHubMember): string[] {
+  return [m.login, m.name || ""].filter(Boolean) as string[];
+}
+
+export function searchGitHub(
+  query: string,
+  cache: GitHubMember[],
+  limit = 8
+): ProviderUserMatch[] {
+  if (!cache.length) return [];
+  if (!query.trim()) {
+    return cache
+      .slice()
+      .sort((a, b) => githubLabel(a).localeCompare(githubLabel(b)))
+      .slice(0, limit)
+      .map((m) => ({
+        provider: "github" as const,
+        id: m.login,
+        handle: m.login,
+        label: githubLabel(m),
+        detail: undefined,
+        avatarUrl: m.avatarUrl ?? undefined,
+      }));
+  }
+  return rankCandidates(query, cache, githubCandidates, limit).map((s) => ({
+    provider: "github" as const,
+    id: s.user.login,
+    handle: s.user.login,
+    label: githubLabel(s.user),
+    detail: undefined,
+    avatarUrl: s.user.avatarUrl ?? undefined,
+    score: s.score,
+  }));
+}
+
+export function resolveGitHubLabel(
+  handle: string,
+  cache: GitHubMember[]
+): string | null {
+  const m = cache.find((x) => x.login === handle);
+  return m ? githubLabel(m) : null;
+}
+
+// Module-level singleton so StepTeam and Settings share one fetch per
+// session. The pool is the union of members across every org the user
+// belongs to, deduped by login.
+let _githubPool: GitHubMember[] | null = null;
+let _githubPoolPromise: Promise<GitHubMember[]> | null = null;
+
+export function getCachedGitHubPool(): GitHubMember[] | null {
+  return _githubPool;
+}
+
+export function invalidateGitHubPool(): void {
+  _githubPool = null;
+  _githubPoolPromise = null;
+}
+
+/**
+ * Loads members across every org the user belongs to. Coalesces concurrent
+ * callers, caches the result for the rest of the session. Returns [] when
+ * the user belongs to no orgs (solo developer, personal repos only).
+ *
+ * Per-org failures are tolerated — a single org's permission error must
+ * not zero out the whole pool.
+ */
+export async function loadGitHubMemberPool(): Promise<GitHubMember[]> {
+  if (_githubPool) return _githubPool;
+  if (_githubPoolPromise) return _githubPoolPromise;
+  _githubPoolPromise = (async () => {
+    try {
+      const orgs = await github.listUserOrgs().catch(() => [] as github.GitHubOrg[]);
+      if (!orgs.length) {
+        _githubPool = [];
+        return _githubPool;
+      }
+      const seen = new Map<string, GitHubMember>();
+      const results = await Promise.all(
+        orgs.map((o) =>
+          github
+            .listOrgMembers(o.login)
+            .catch(() => [] as GitHubMember[])
+        )
+      );
+      for (const list of results) {
+        for (const m of list) {
+          if (!seen.has(m.login)) seen.set(m.login, m);
+        }
+      }
+      _githubPool = Array.from(seen.values());
+      return _githubPool;
+    } finally {
+      // Always clear the in-flight slot so a rejected promise can't poison
+      // every subsequent caller for the rest of the session.
+      _githubPoolPromise = null;
+    }
+  })();
+  return _githubPoolPromise;
+}


### PR DESCRIPTION
## Summary

This branch lands two distinct features. Heads-up: it's a chunky one — happy to split if you'd rather review them separately.

### 1. Codex CLI provider + categorized LLM picker
- New CLI provider entry alongside Anthropic / OpenAI / OpenRouter
- Categorized picker UI in StepLLM and Settings (lanes A–E from prior plan)
- NDJSON parser for the real Codex CLI v0.125 output
- Tauri capabilities: \`shell:allow-spawn\` + \`allow-kill\`, fs scope for temp workspace
- Codex spawn wrapped in \`sh -c < /dev/null\` to close stdin and prevent hang
- Spawn flags fixed: drop nonexistent \`--ask-for-approval\`, add \`--skip-git-repo-check\` + \`--ephemeral\`

### 2. Search-and-pick teammate mapping (latest commit)
Rewrites the onboarding team-mapping step to fix three user-reported bugs:

**Fixes the silent cross-field overwrite.** Typing into the GitHub handle column would feed through the Slack fuzzy matcher and quietly replace the previously-picked Slack user. Now each column is independent — no field's onChange ever mutates another field's value.

**Fixes the unscoped GitHub picker.** Old implementation hit \`/search/users\` against all of GitHub. Searching \"Mani\" returned random strangers from the global namespace. Now scoped to members of orgs the authenticated user belongs to via \`/user/orgs\` + GraphQL \`membersWithRole\` — pulls login + name + avatar in one paginated call, capped at 2000.

**Adds Linear + Jira columns.** Schema already had \`linear_username\` / \`jira_username\` from earlier migrations but the onboarding step only rendered Slack + GitHub. Both columns now have real search-and-pick comboboxes.

**Other:**
- New \`UserCombobox\` with debounce, abort-on-unmount, keyboard nav, and \"Backspace does not silently clear the value\" semantics
- \"Find matches across all\" button per row searches all four providers in parallel and shows a confirmation panel; never overwrites a column the user already set
- Settings team panel uses the same combobox so users don't relearn the UI in two places
- New \`read:org\` OAuth scope; reconnect prompts inline in StepGitHub and Settings when an existing token is missing it
- Dropdown layout fixed (\`min-w-full w-max max-w-[360px]\`, no single-line truncate, \`z-30\`) so \`@longusername\` is readable in narrow columns

## Test plan

- [x] \`npx tsc -p tsconfig.json --noEmit\` clean
- [x] \`npx vitest run\` — 229/229 passing (20 new tests)
- [x] \`npm run build\` green
- [ ] Manual: walk onboarding to TeamStep, confirm GitHub dropdown shows org members (not strangers)
- [ ] Manual: type into GitHub column with a Slack value already set — confirm Slack stays put
- [ ] Manual: existing user with old token → reconnect prompt appears in Settings
- [ ] Manual: \"Find matches\" with display name, confirm one click maps all 4 providers