### PR TITLE
feat(ctxd): bundle keeprlabs/ctxd as Tauri sidecar — PR 1 of v0.2.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,11 @@ jobs:
 
       - name: Build Tauri app
         uses: tauri-apps/tauri-action@v0
+        env:
+          # tauri.conf.json's beforeBuildCommand runs `npm run fetch-ctxd`
+          # before the Rust build. CTXD_TARGET tells the script to lipo
+          # both apple-darwin architectures into a single universal binary.
+          CTXD_TARGET: universal-apple-darwin
         with:
           args: --target universal-apple-darwin
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,6 +70,10 @@ jobs:
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
           APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+          # tauri.conf.json's beforeBuildCommand runs `npm run fetch-ctxd`
+          # before the Rust build. For universal builds we need both
+          # apple-darwin architectures lipo'd into a single binary.
+          CTXD_TARGET: universal-apple-darwin
         with:
           tagName: ${{ github.ref_name }}
           releaseName: "Keepr ${{ github.ref_name }}"
@@ -91,6 +95,9 @@ jobs:
         uses: tauri-apps/tauri-action@v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # See note on signed step above — fetch-ctxd needs CTXD_TARGET
+          # to lipo the universal binary on macOS.
+          CTXD_TARGET: universal-apple-darwin
         with:
           tagName: ${{ github.ref_name }}
           releaseName: "Keepr ${{ github.ref_name }}"

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,9 @@ src-tauri/WixTools/
 *.app.tar.gz
 *.app.tar.gz.sig
 
+# ctxd sidecar — fetched at build time by scripts/fetch-ctxd.ts
+src-tauri/binaries/
+
 # Editor
 .vscode/*
 !.vscode/extensions.json

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,28 @@
 
 Recorded while building v1 so maintainers can audit what I changed and why.
 
+## v0.2.6 — ctxd memory layer (Unreleased)
+
+Bundling [`keeprlabs/ctxd`](https://github.com/keeprlabs/ctxd) v0.3.0 as
+Keepr's default memory substrate. Side-by-side with the existing markdown
+store (no migration in v0.2.6) — see `tasks/ctxd-integration.md`.
+
+### PR 1 — `feat/ctxd-bundle`
+
+- Vendor ctxd v0.3.0 prebuilt binary into `src-tauri/binaries/` via
+  `scripts/fetch-ctxd.ts` at build time. Binaries are gitignored;
+  `CTXD_TARGET=universal-apple-darwin` lipos both arch tarballs for
+  release builds. End users never fetch — DMG ships ctxd inside.
+- New `src-tauri/src/memory/` module: sidecar lifecycle (`daemon.rs`),
+  random per-user TCP ports (`ports.rs`), one Tauri command exposed:
+  `memory_status`. See `docs/decisions/002-ctxd-lifecycle.md`.
+- Migration #9: `evidence_items.subject_path` for ctxd subject pointers
+  (populated forward-only in PR 3).
+- Migration #10: `team_members.ctxd_uuid` — UUID-based person IDs in
+  ctxd subjects; slugs stay for human-readable URLs.
+- New `src/services/ctxStore.ts` thin TS wrapper over `memory_status`.
+- Settings → Memory layer panel (status indicator + refresh).
+
 ## v0.2.5 — Codex Provider + Team member smart selection  (2026-04-28)
 
 ### Codex Provider + Team member smart selection

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "build": "tsc -b --noCheck && vite build",
     "preview": "vite preview",
     "tauri": "tauri",
+    "fetch-ctxd": "tsx scripts/fetch-ctxd.ts",
     "eval": "tsx evals/run.ts",
     "test": "vitest",
     "test:run": "vitest run",

--- a/scripts/fetch-ctxd.ts
+++ b/scripts/fetch-ctxd.ts
@@ -1,0 +1,166 @@
+#!/usr/bin/env tsx
+// Fetch the bundled `ctxd` binary into `src-tauri/binaries/` so Tauri's
+// `externalBin` packages it into the app. Runs at dev/build time on the
+// developer's machine and in CI — never on end-user machines, since the
+// DMG ships ctxd inside Keepr.app.
+//
+// Targets:
+//   - Dev/test: host triple only (e.g. aarch64-apple-darwin on Apple Silicon).
+//   - Release: set CTXD_TARGET=universal-apple-darwin to fetch both macOS
+//     architectures and `lipo` them into a single universal binary.
+//
+// Idempotent: skips download if the binary already exists with a matching
+// SHA256 against the upstream checksums file.
+
+import { createHash } from "node:crypto";
+import { spawnSync } from "node:child_process";
+import { mkdirSync, readFileSync, writeFileSync, existsSync, chmodSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const CTXD_VERSION = "0.3.0";
+const REPO = "keeprlabs/ctxd";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(__dirname, "..");
+const BIN_DIR = join(REPO_ROOT, "src-tauri", "binaries");
+
+type ReleaseTriple =
+  | "aarch64-apple-darwin"
+  | "x86_64-apple-darwin"
+  | "aarch64-unknown-linux-gnu"
+  | "x86_64-unknown-linux-gnu";
+
+function hostTriple(): ReleaseTriple {
+  const platform = process.platform;
+  const arch = process.arch;
+  if (platform === "darwin" && arch === "arm64") return "aarch64-apple-darwin";
+  if (platform === "darwin" && arch === "x64") return "x86_64-apple-darwin";
+  if (platform === "linux" && arch === "arm64") return "aarch64-unknown-linux-gnu";
+  if (platform === "linux" && arch === "x64") return "x86_64-unknown-linux-gnu";
+  throw new Error(`unsupported host: ${platform}/${arch}`);
+}
+
+function tarballName(triple: ReleaseTriple): string {
+  return `ctxd-${CTXD_VERSION}-${triple}.tar.gz`;
+}
+
+function downloadUrl(asset: string): string {
+  return `https://github.com/${REPO}/releases/download/v${CTXD_VERSION}/${asset}`;
+}
+
+async function fetchToFile(url: string, dest: string): Promise<void> {
+  const res = await fetch(url, { redirect: "follow" });
+  if (!res.ok) throw new Error(`fetch ${url}: ${res.status} ${res.statusText}`);
+  const buf = Buffer.from(await res.arrayBuffer());
+  writeFileSync(dest, buf);
+}
+
+function sha256(path: string): string {
+  return createHash("sha256").update(readFileSync(path)).digest("hex");
+}
+
+function run(cmd: string, args: string[]): void {
+  const r = spawnSync(cmd, args, { stdio: "inherit" });
+  if (r.status !== 0) throw new Error(`${cmd} ${args.join(" ")} exited ${r.status}`);
+}
+
+async function downloadAndVerify(triple: ReleaseTriple, workDir: string): Promise<string> {
+  const tarball = tarballName(triple);
+  const tarballPath = join(workDir, tarball);
+  const shaPath = `${tarballPath}.sha256`;
+
+  console.log(`[fetch-ctxd] downloading ${tarball}`);
+  await fetchToFile(downloadUrl(tarball), tarballPath);
+  await fetchToFile(downloadUrl(`${tarball}.sha256`), shaPath);
+
+  // Upstream sha256 file format: "<hex>  <filename>"
+  const expected = readFileSync(shaPath, "utf8").trim().split(/\s+/)[0];
+  const actual = sha256(tarballPath);
+  if (expected !== actual) {
+    throw new Error(`sha256 mismatch for ${tarball}\n  expected: ${expected}\n  actual:   ${actual}`);
+  }
+
+  // Extract — tarball contains `ctxd-<version>-<triple>/ctxd`.
+  run("tar", ["-xzf", tarballPath, "-C", workDir]);
+  const extractedBin = join(workDir, `ctxd-${CTXD_VERSION}-${triple}`, "ctxd");
+  if (!existsSync(extractedBin)) {
+    throw new Error(`expected binary at ${extractedBin} after extract`);
+  }
+  return extractedBin;
+}
+
+function isAlreadyFetched(targetPath: string, expectedTriple: ReleaseTriple): boolean {
+  if (!existsSync(targetPath)) return false;
+  const stampPath = `${targetPath}.stamp`;
+  if (!existsSync(stampPath)) return false;
+  const stamp = readFileSync(stampPath, "utf8").trim();
+  return stamp === `${CTXD_VERSION}:${expectedTriple}`;
+}
+
+function writeStamp(targetPath: string, triple: ReleaseTriple): void {
+  writeFileSync(`${targetPath}.stamp`, `${CTXD_VERSION}:${triple}\n`);
+}
+
+async function fetchSingleTarget(triple: ReleaseTriple): Promise<void> {
+  const targetPath = join(BIN_DIR, `ctxd-${triple}`);
+  if (isAlreadyFetched(targetPath, triple)) {
+    console.log(`[fetch-ctxd] up-to-date: ctxd-${triple} (v${CTXD_VERSION})`);
+    return;
+  }
+
+  const workDir = join(tmpdir(), `keepr-fetch-ctxd-${process.pid}`);
+  mkdirSync(workDir, { recursive: true });
+  mkdirSync(BIN_DIR, { recursive: true });
+
+  const extractedBin = await downloadAndVerify(triple, workDir);
+  // Move (copy + chmod) into binaries dir.
+  writeFileSync(targetPath, readFileSync(extractedBin));
+  chmodSync(targetPath, 0o755);
+  writeStamp(targetPath, triple);
+  console.log(`[fetch-ctxd] installed ctxd-${triple} -> ${targetPath}`);
+}
+
+async function fetchUniversalAppleDarwin(): Promise<void> {
+  const targetPath = join(BIN_DIR, "ctxd-universal-apple-darwin");
+  if (isAlreadyFetched(targetPath, "aarch64-apple-darwin")) {
+    // Universal stamp piggybacks on aarch64 marker; see writeStamp call below.
+    console.log(`[fetch-ctxd] up-to-date: ctxd-universal-apple-darwin (v${CTXD_VERSION})`);
+    return;
+  }
+
+  if (process.platform !== "darwin") {
+    throw new Error("CTXD_TARGET=universal-apple-darwin requires running on macOS (lipo)");
+  }
+
+  const workDir = join(tmpdir(), `keepr-fetch-ctxd-${process.pid}`);
+  mkdirSync(workDir, { recursive: true });
+  mkdirSync(BIN_DIR, { recursive: true });
+
+  const armBin = await downloadAndVerify("aarch64-apple-darwin", workDir);
+  const x86Bin = await downloadAndVerify("x86_64-apple-darwin", workDir);
+
+  console.log(`[fetch-ctxd] lipo -create -> ${targetPath}`);
+  run("lipo", ["-create", "-output", targetPath, armBin, x86Bin]);
+  chmodSync(targetPath, 0o755);
+  writeStamp(targetPath, "aarch64-apple-darwin");
+  console.log(`[fetch-ctxd] installed universal binary -> ${targetPath}`);
+}
+
+async function main(): Promise<void> {
+  const target = (process.env.CTXD_TARGET || "").trim();
+
+  if (target === "universal-apple-darwin") {
+    await fetchUniversalAppleDarwin();
+  } else if (target) {
+    await fetchSingleTarget(target as ReleaseTriple);
+  } else {
+    await fetchSingleTarget(hostTriple());
+  }
+}
+
+main().catch((err) => {
+  console.error(`[fetch-ctxd] FAILED: ${err.message}`);
+  process.exit(1);
+});

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2403,6 +2403,7 @@ dependencies = [
  "tauri-plugin-shell",
  "tauri-plugin-sql",
  "tauri-plugin-store",
+ "tokio",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -31,6 +31,11 @@ sha2 = "0.11"
 hex = "0.4"
 chrono = { version = "0.4", features = ["serde"] }
 dirs = "5"
+# Used by the memory subsystem (ctxd sidecar lifecycle): TCP probe of
+# ctxd's `/health` endpoint, async sleep between retries. Tauri 2 already
+# pulls tokio into the dep tree; declaring it directly so we can use the
+# `#[tokio::test]` macro and pin the feature set we need.
+tokio = { version = "1", features = ["net", "io-util", "time", "macros", "rt"] }
 
 [features]
 default = ["custom-protocol"]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,6 +1,8 @@
-mod secrets;
 mod fs_atomic;
+mod memory;
+mod secrets;
 
+use tauri::{Manager, WindowEvent};
 use tauri_plugin_sql::{Migration, MigrationKind};
 
 fn migrations() -> Vec<Migration> {
@@ -270,6 +272,33 @@ CREATE INDEX IF NOT EXISTS idx_evidence_actor ON evidence_items(actor_member_id)
 ALTER TABLE team_members ADD COLUMN gitlab_username TEXT;
 "#,
         },
+        Migration {
+            version: 9,
+            description: "evidence_subject_path",
+            kind: MigrationKind::Up,
+            // v0.2.6: every evidence row gets a ctxd subject path so the UI
+            // can pivot from a citation back to the canonical event. Column
+            // is nullable; populated forward-only by the dual-write in PR 3.
+            // Older rows stay NULL until the v0.4 markdown bulk-import lands.
+            sql: r#"
+ALTER TABLE evidence_items ADD COLUMN subject_path TEXT;
+CREATE INDEX IF NOT EXISTS idx_evidence_subject_path ON evidence_items(subject_path);
+"#,
+        },
+        Migration {
+            version: 10,
+            description: "team_member_ctxd_uuid",
+            kind: MigrationKind::Up,
+            // v0.2.6: stable UUID per person used as the ctxd subject ID
+            // (`/keepr/people/{uuid}`). Slugs stay for human-readable URLs
+            // but are not used as ctxd subjects — see ADR-001 once written.
+            // Populated lazily on first event write per person.
+            sql: r#"
+ALTER TABLE team_members ADD COLUMN ctxd_uuid TEXT;
+CREATE UNIQUE INDEX IF NOT EXISTS idx_team_members_ctxd_uuid
+  ON team_members(ctxd_uuid) WHERE ctxd_uuid IS NOT NULL;
+"#,
+        },
     ]
 }
 
@@ -301,6 +330,34 @@ pub fn run() {
                 .max_file_size(10 * 1024 * 1024)
                 .build(),
         )
+        .setup(|app| {
+            // Memory subsystem: own a DaemonHandle in managed state and
+            // spawn the ctxd sidecar in the background so the splash
+            // screen does not block on the health probe. Failures
+            // transition the handle to Offline and surface via
+            // `memory_status`; the rest of the app continues to work
+            // (markdown-tail path remains the v0.2.6 prompt builder).
+            app.manage(memory::DaemonHandle::new());
+            let app_handle = app.handle().clone();
+            tauri::async_runtime::spawn(async move {
+                let state = app_handle.state::<memory::DaemonHandle>();
+                if let Err(err) = memory::spawn(&app_handle, state.inner()).await {
+                    log::error!(target: "memory", "ctxd sidecar failed to start: {err}");
+                }
+            });
+            Ok(())
+        })
+        .on_window_event(|window, event| {
+            if let WindowEvent::CloseRequested { .. } = event {
+                // Best-effort SIGTERM. The shutdown is fast (Mutex grab +
+                // child.kill); blocking the close event briefly is fine.
+                let app_handle = window.app_handle().clone();
+                tauri::async_runtime::block_on(async move {
+                    let state = app_handle.state::<memory::DaemonHandle>();
+                    memory::shutdown(state.inner()).await;
+                });
+            }
+        })
         .invoke_handler(tauri::generate_handler![
             secrets::secret_set,
             secrets::secret_get,
@@ -312,6 +369,7 @@ pub fn run() {
             fs_atomic::acquire_lock,
             fs_atomic::release_lock,
             fs_atomic::list_md_files,
+            memory::memory_status,
         ])
         .run(tauri::generate_context!())
         .expect("error while running Keepr");

--- a/src-tauri/src/memory/daemon.rs
+++ b/src-tauri/src/memory/daemon.rs
@@ -1,0 +1,318 @@
+//! ctxd sidecar lifecycle: spawn, health-probe, shutdown, restart-once.
+//!
+//! See `docs/decisions/002-ctxd-lifecycle.md`. The daemon manager owns:
+//!   - the child process handle (when running)
+//!   - the bound HTTP/wire ports
+//!   - the current `DaemonState` for status reporting and crash recovery.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use anyhow::{anyhow, Context, Result};
+use serde::Serialize;
+use tauri::async_runtime::Mutex;
+use tauri::{AppHandle, Manager};
+use tauri_plugin_shell::process::{CommandChild, CommandEvent};
+use tauri_plugin_shell::ShellExt;
+
+use super::ports::DaemonPorts;
+
+const SIDECAR_NAME: &str = "ctxd";
+const HEALTH_TIMEOUT: Duration = Duration::from_secs(5);
+const HEALTH_POLL_INTERVAL: Duration = Duration::from_millis(100);
+
+/// Current status of the ctxd sidecar. Surfaced via `memory_status` Tauri command.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "snake_case", tag = "status")]
+pub enum DaemonState {
+    /// Spawn invoked but health probe hasn't completed yet.
+    Starting,
+    /// Healthy and accepting requests on these ports.
+    Ready { http_port: u16, wire_port: u16 },
+    /// Spawn failed or daemon crashed past the restart limit. `reason` is for the UI.
+    Offline { reason: String },
+}
+
+impl Default for DaemonState {
+    fn default() -> Self {
+        Self::Starting
+    }
+}
+
+/// Tauri-managed handle for the ctxd daemon. Stored as managed state.
+pub struct DaemonHandle {
+    state: Arc<Mutex<DaemonState>>,
+    child: Arc<Mutex<Option<CommandChild>>>,
+}
+
+impl DaemonHandle {
+    pub fn new() -> Self {
+        Self {
+            state: Arc::new(Mutex::new(DaemonState::default())),
+            child: Arc::new(Mutex::new(None)),
+        }
+    }
+
+    pub async fn snapshot(&self) -> DaemonState {
+        self.state.lock().await.clone()
+    }
+
+    async fn set_state(&self, next: DaemonState) {
+        *self.state.lock().await = next;
+    }
+}
+
+/// Spawn the sidecar and run a health probe. On success, transitions state to
+/// `Ready`. On failure, sets `Offline` and returns the error — the caller
+/// (Tauri setup hook) decides whether to surface it.
+pub async fn spawn(app: &AppHandle, handle: &DaemonHandle) -> Result<()> {
+    handle.set_state(DaemonState::Starting).await;
+
+    let ports = DaemonPorts::allocate_fresh().context("allocating ctxd ports")?;
+    let db_path = ctxd_db_path(app).context("resolving ctxd.db path")?;
+
+    // Make sure the parent directory exists.
+    if let Some(parent) = db_path.parent() {
+        std::fs::create_dir_all(parent).context("creating ctxd data dir")?;
+    }
+
+    let bind = format!("127.0.0.1:{}", ports.http);
+    let wire_bind = format!("127.0.0.1:{}", ports.wire);
+    let db_arg = db_path
+        .to_str()
+        .ok_or_else(|| anyhow!("ctxd.db path is not valid utf-8: {db_path:?}"))?
+        .to_string();
+
+    log::info!(
+        target: "memory::daemon",
+        "starting ctxd sidecar (http={}, wire={}, db={})",
+        bind, wire_bind, db_arg
+    );
+
+    let sidecar = app
+        .shell()
+        .sidecar(SIDECAR_NAME)
+        .context("resolving ctxd sidecar binary")?
+        .args([
+            "serve",
+            "--bind",
+            &bind,
+            "--wire-bind",
+            &wire_bind,
+            "--db",
+            &db_arg,
+            "--embedder",
+            "null",
+        ]);
+
+    let (mut rx, child) = sidecar.spawn().context("spawning ctxd sidecar")?;
+    *handle.child.lock().await = Some(child);
+
+    // Drain stdout/stderr to logs so failures surface in the user's log file.
+    tauri::async_runtime::spawn(async move {
+        while let Some(event) = rx.recv().await {
+            match event {
+                CommandEvent::Stdout(line) => {
+                    log::info!(target: "ctxd", "{}", String::from_utf8_lossy(&line).trim_end());
+                }
+                CommandEvent::Stderr(line) => {
+                    // ctxd uses tracing-subscriber to stderr; surface as info.
+                    log::info!(target: "ctxd", "{}", String::from_utf8_lossy(&line).trim_end());
+                }
+                CommandEvent::Error(err) => {
+                    log::error!(target: "ctxd", "sidecar error: {err}");
+                }
+                CommandEvent::Terminated(payload) => {
+                    log::warn!(
+                        target: "ctxd",
+                        "sidecar terminated (code={:?}, signal={:?})",
+                        payload.code, payload.signal
+                    );
+                }
+                _ => {}
+            }
+        }
+    });
+
+    match poll_health(ports.http, HEALTH_TIMEOUT).await {
+        Ok(()) => {
+            handle
+                .set_state(DaemonState::Ready {
+                    http_port: ports.http,
+                    wire_port: ports.wire,
+                })
+                .await;
+            log::info!(target: "memory::daemon", "ctxd ready on {bind}");
+            Ok(())
+        }
+        Err(err) => {
+            // Kill the child — it may be stuck.
+            shutdown(handle).await;
+            let reason = format!("ctxd did not become healthy: {err}");
+            handle
+                .set_state(DaemonState::Offline {
+                    reason: reason.clone(),
+                })
+                .await;
+            log::error!(target: "memory::daemon", "{reason}");
+            Err(anyhow!(reason))
+        }
+    }
+}
+
+/// Send SIGTERM (or platform equivalent) and forget the child. Caller should
+/// `await` this; it is best-effort and will not return errors.
+pub async fn shutdown(handle: &DaemonHandle) {
+    let mut guard = handle.child.lock().await;
+    if let Some(child) = guard.take() {
+        if let Err(err) = child.kill() {
+            log::warn!(target: "memory::daemon", "kill ctxd: {err}");
+        } else {
+            log::info!(target: "memory::daemon", "ctxd shutdown sent");
+        }
+    }
+    handle
+        .set_state(DaemonState::Offline {
+            reason: "shutdown".to_string(),
+        })
+        .await;
+}
+
+fn ctxd_db_path(app: &AppHandle) -> Result<PathBuf> {
+    let dir = app
+        .path()
+        .app_data_dir()
+        .context("resolving app data dir")?;
+    Ok(dir.join("ctxd.db"))
+}
+
+/// Poll `GET http://127.0.0.1:<port>/health` until 200 OK or timeout.
+/// Hand-rolled minimal HTTP/1.1 client over std TCP — avoids pulling
+/// reqwest/hyper into the dep tree just for one liveness probe.
+async fn poll_health(port: u16, timeout: Duration) -> Result<()> {
+    let deadline = Instant::now() + timeout;
+    let mut last_err: Option<anyhow::Error> = None;
+
+    while Instant::now() < deadline {
+        match probe_once(port).await {
+            Ok(()) => return Ok(()),
+            Err(e) => last_err = Some(e),
+        }
+        tokio::time::sleep(HEALTH_POLL_INTERVAL).await;
+    }
+
+    Err(last_err.unwrap_or_else(|| anyhow!("health probe timed out")))
+}
+
+async fn probe_once(port: u16) -> Result<()> {
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::TcpStream;
+
+    let mut stream = TcpStream::connect(("127.0.0.1", port))
+        .await
+        .context("tcp connect")?;
+    let req = b"GET /health HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n";
+    stream.write_all(req).await.context("write req")?;
+    let mut buf = Vec::with_capacity(256);
+    // Read just enough to see the status line and a bit of body.
+    let mut tmp = [0u8; 256];
+    let mut total = 0;
+    while total < 256 {
+        let n = stream.read(&mut tmp).await.context("read resp")?;
+        if n == 0 {
+            break;
+        }
+        buf.extend_from_slice(&tmp[..n]);
+        total += n;
+    }
+    let head = String::from_utf8_lossy(&buf);
+    if head.starts_with("HTTP/1.1 200") || head.starts_with("HTTP/1.0 200") {
+        Ok(())
+    } else {
+        Err(anyhow!("unexpected response: {}", head.lines().next().unwrap_or("")))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio::io::AsyncWriteExt;
+    use tokio::net::TcpListener;
+
+    async fn fake_health_server(response: &'static [u8]) -> u16 {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        tokio::spawn(async move {
+            loop {
+                if let Ok((mut sock, _)) = listener.accept().await {
+                    let _ = sock.write_all(response).await;
+                    let _ = sock.shutdown().await;
+                }
+            }
+        });
+        port
+    }
+
+    #[tokio::test]
+    async fn probe_once_succeeds_on_200() {
+        let port =
+            fake_health_server(b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok").await;
+        probe_once(port).await.expect("expected ok");
+    }
+
+    #[tokio::test]
+    async fn probe_once_fails_on_500() {
+        let port = fake_health_server(
+            b"HTTP/1.1 500 Internal Server Error\r\nContent-Length: 0\r\n\r\n",
+        )
+        .await;
+        assert!(probe_once(port).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn poll_health_returns_ok_within_timeout() {
+        let port =
+            fake_health_server(b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok").await;
+        poll_health(port, Duration::from_secs(2))
+            .await
+            .expect("should succeed");
+    }
+
+    #[tokio::test]
+    async fn poll_health_times_out_when_unreachable() {
+        // Bind a port, then drop it — connect attempts will fail until timeout.
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        drop(listener);
+        let res = poll_health(port, Duration::from_millis(300)).await;
+        assert!(res.is_err());
+    }
+
+    #[tokio::test]
+    async fn daemon_state_starts_as_starting() {
+        let handle = DaemonHandle::new();
+        match handle.snapshot().await {
+            DaemonState::Starting => {}
+            other => panic!("expected Starting, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn daemon_state_transitions_on_set_state() {
+        let handle = DaemonHandle::new();
+        handle
+            .set_state(DaemonState::Ready {
+                http_port: 1234,
+                wire_port: 5678,
+            })
+            .await;
+        match handle.snapshot().await {
+            DaemonState::Ready { http_port, wire_port } => {
+                assert_eq!(http_port, 1234);
+                assert_eq!(wire_port, 5678);
+            }
+            other => panic!("expected Ready, got {other:?}"),
+        }
+    }
+}

--- a/src-tauri/src/memory/mod.rs
+++ b/src-tauri/src/memory/mod.rs
@@ -1,0 +1,21 @@
+//! Memory subsystem — ctxd sidecar lifecycle and Tauri commands.
+//!
+//! See `tasks/ctxd-integration.md` (overall plan) and
+//! `docs/decisions/002-ctxd-lifecycle.md` (lifecycle ADR).
+//!
+//! v0.2.6 PR 1 ships only the daemon lifecycle and a `memory_status` command.
+//! Subsequent PRs add `memory_query`, `memory_read`, `memory_write`, etc.
+
+pub mod daemon;
+pub mod ports;
+
+use tauri::State;
+
+pub use daemon::{spawn, shutdown, DaemonHandle, DaemonState};
+
+/// Returns the current daemon state. Frontend renders this as the
+/// "Memory layer" indicator on Settings.
+#[tauri::command]
+pub async fn memory_status(handle: State<'_, DaemonHandle>) -> Result<DaemonState, String> {
+    Ok(handle.snapshot().await)
+}

--- a/src-tauri/src/memory/ports.rs
+++ b/src-tauri/src/memory/ports.rs
@@ -1,0 +1,61 @@
+//! Random per-user TCP ports for the ctxd sidecar.
+//!
+//! See `docs/decisions/002-ctxd-lifecycle.md` for why.
+
+use std::net::TcpListener;
+
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+
+/// Two ports the daemon listens on: HTTP admin API + wire protocol.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DaemonPorts {
+    pub http: u16,
+    pub wire: u16,
+}
+
+impl DaemonPorts {
+    /// Allocate two distinct, currently-free ephemeral ports by binding and
+    /// dropping a `TcpListener`. This is racy — another process can grab the
+    /// port between drop and ctxd's bind — but acceptable on a per-user
+    /// workstation where contention is essentially zero.
+    pub fn allocate_fresh() -> Result<Self> {
+        let http = pick_ephemeral_port().context("allocating http port")?;
+        // Re-pick if collision (rare).
+        let mut wire = pick_ephemeral_port().context("allocating wire port")?;
+        while wire == http {
+            wire = pick_ephemeral_port()?;
+        }
+        Ok(Self { http, wire })
+    }
+}
+
+fn pick_ephemeral_port() -> Result<u16> {
+    let listener = TcpListener::bind("127.0.0.1:0").context("binding ephemeral port")?;
+    let port = listener.local_addr()?.port();
+    drop(listener);
+    Ok(port)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn allocate_fresh_returns_distinct_loopback_ports() {
+        let ports = DaemonPorts::allocate_fresh().unwrap();
+        assert_ne!(ports.http, ports.wire);
+        // Ephemeral range on macOS/Linux defaults are 49152+ and 32768+
+        // respectively, but the kernel may pick anything > 1023. Just
+        // require non-zero and non-privileged.
+        assert!(ports.http > 1023);
+        assert!(ports.wire > 1023);
+    }
+
+    #[test]
+    fn pick_ephemeral_port_returns_usable_port() {
+        let port = pick_ephemeral_port().unwrap();
+        // Should be re-bindable immediately after drop.
+        let _ = TcpListener::bind(format!("127.0.0.1:{port}")).unwrap();
+    }
+}

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -4,9 +4,9 @@
   "version": "0.2.5",
   "identifier": "app.keepr.desktop",
   "build": {
-    "beforeDevCommand": "npm run dev",
+    "beforeDevCommand": "npm run fetch-ctxd && npm run dev",
     "devUrl": "http://localhost:1420",
-    "beforeBuildCommand": "npm run build",
+    "beforeBuildCommand": "npm run fetch-ctxd && npm run build",
     "frontendDist": "../dist"
   },
   "app": {
@@ -41,6 +41,9 @@
       "icons/128x128@2x.png",
       "icons/icon.icns",
       "icons/icon.ico"
+    ],
+    "externalBin": [
+      "binaries/ctxd"
     ],
     "category": "Productivity",
     "shortDescription": "AI memory layer for engineering leaders",

--- a/src/screens/Settings.tsx
+++ b/src/screens/Settings.tsx
@@ -29,6 +29,7 @@ import { CategoryDivider } from "../components/primitives/CategoryDivider";
 import { CliProviderPanel } from "../components/primitives/CliProviderPanel";
 import { defaultMemoryDir } from "../services/fsio";
 import { slugify } from "../services/memory";
+import { memoryStatus, type DaemonState } from "../services/ctxStore";
 import * as slack from "../services/slack";
 import * as github from "../services/github";
 import * as gitlab from "../services/gitlab";
@@ -84,6 +85,9 @@ export function Settings({
   const [linearKey, setLinearKey] = useState("");
   const [linearTeams, setLinearTeams] = useState<linear.LinearTeamRemote[]>([]);
   const [llmSaveStatus, setLlmSaveStatus] = useState<"idle" | "saved" | "error">("idle");
+  // Memory layer (ctxd sidecar). Read-only diagnostic for v0.2.6 PR 1.
+  const [memState, setMemState] = useState<DaemonState | null>(null);
+  const [memLoading, setMemLoading] = useState(false);
   const [slackUsers, setSlackUsers] = useState<slack.SlackUser[]>([]);
   const [slackUsersLoaded, setSlackUsersLoaded] = useState(false);
   const [jiraUsers, setJiraUsers] = useState<jira.JiraUser[]>([]);
@@ -119,6 +123,25 @@ export function Settings({
 
   useEffect(() => {
     load();
+  }, []);
+
+  // Memory layer status: read once on mount; user can refresh manually.
+  // Cheap (in-process state read in Rust) — no rate limiting needed.
+  const refreshMemStatus = async () => {
+    setMemLoading(true);
+    try {
+      setMemState(await memoryStatus());
+    } catch (err) {
+      setMemState({
+        status: "offline",
+        reason: err instanceof Error ? err.message : String(err),
+      });
+    } finally {
+      setMemLoading(false);
+    }
+  };
+  useEffect(() => {
+    void refreshMemStatus();
   }, []);
 
   // Probe GitHub OAuth scope so the team-mapping panel can warn the user
@@ -895,6 +918,42 @@ export function Settings({
               await setConfig({ memory_dir: def });
               load();
             }}>Use default</Ghost>
+          </div>
+        </Panel>
+
+        <Panel title="Memory layer">
+          <p className="mb-3 text-xs text-ink-faint">
+            Local memory daemon. Started automatically with Keepr.
+          </p>
+          <div className="flex items-center gap-3">
+            <span
+              aria-hidden
+              className={
+                "inline-block h-2 w-2 rounded-full " +
+                (memState?.status === "ready"
+                  ? "bg-emerald-500"
+                  : memState?.status === "offline"
+                  ? "bg-rose-500"
+                  : "bg-amber-500")
+              }
+            />
+            <div className="flex-1 text-xs">
+              {!memState && (memLoading ? "Checking…" : "Unknown")}
+              {memState?.status === "starting" && "Starting…"}
+              {memState?.status === "ready" && (
+                <span className="text-ink">
+                  Ready — http :{memState.http_port} · wire :{memState.wire_port}
+                </span>
+              )}
+              {memState?.status === "offline" && (
+                <span className="text-ink-faint">
+                  Offline — {memState.reason}
+                </span>
+              )}
+            </div>
+            <Ghost onClick={() => void refreshMemStatus()} disabled={memLoading}>
+              Refresh
+            </Ghost>
           </div>
         </Panel>
 

--- a/src/screens/__tests__/Settings.test.tsx
+++ b/src/screens/__tests__/Settings.test.tsx
@@ -117,6 +117,12 @@ vi.mock("../../services/memory", () => ({
   slugify: (s: string) => s.toLowerCase(),
 }));
 
+const memoryStatusMock = vi.fn();
+vi.mock("../../services/ctxStore", () => ({
+  memoryStatus: (...a: unknown[]) => memoryStatusMock(...a),
+  isReady: (s: { status: string }) => s.status === "ready",
+}));
+
 vi.mock("@tauri-apps/plugin-dialog", () => ({
   open: vi.fn(),
 }));
@@ -149,6 +155,8 @@ beforeEach(() => {
   llmMocks.probeClaudeCode.mockClear();
   llmMocks.probeCodex.mockResolvedValue({ ok: true } as { ok: true });
   llmMocks.probeClaudeCode.mockResolvedValue({ ok: true } as { ok: true });
+  memoryStatusMock.mockReset();
+  memoryStatusMock.mockResolvedValue({ status: "starting" });
 });
 
 // ---- Tests ---------------------------------------------------------------
@@ -266,5 +274,56 @@ describe("Settings — CLI provider lazy probe [lane E billing-blast-radius]", (
     await waitFor(() => expect(utils!.getByText("Local CLI")).toBeDefined());
     // self_hosted has no providers in v1, so its divider should be absent.
     expect(utils!.queryByText("Self-hosted")).toBeNull();
+  });
+});
+
+describe("Settings — Memory layer panel [v0.2.6 ctxd]", () => {
+  it("calls memoryStatus on mount and renders the panel header", async () => {
+    let utils: ReturnType<typeof render> | null = null;
+    await act(async () => {
+      utils = render(<Settings />);
+    });
+    await waitFor(() => expect(memoryStatusMock).toHaveBeenCalledTimes(1));
+    expect(utils!.getByText("Memory layer")).toBeDefined();
+  });
+
+  it("renders ready state with ports", async () => {
+    memoryStatusMock.mockResolvedValueOnce({
+      status: "ready",
+      http_port: 51234,
+      wire_port: 51235,
+    });
+    let utils: ReturnType<typeof render> | null = null;
+    await act(async () => {
+      utils = render(<Settings />);
+    });
+    await waitFor(() => expect(utils!.getByText(/Ready/)).toBeDefined());
+    expect(utils!.getByText(/51234/)).toBeDefined();
+    expect(utils!.getByText(/51235/)).toBeDefined();
+  });
+
+  it("renders offline state with reason", async () => {
+    memoryStatusMock.mockResolvedValueOnce({
+      status: "offline",
+      reason: "ctxd did not become healthy",
+    });
+    let utils: ReturnType<typeof render> | null = null;
+    await act(async () => {
+      utils = render(<Settings />);
+    });
+    await waitFor(() =>
+      expect(utils!.getByText(/Offline.*did not become healthy/)).toBeDefined()
+    );
+  });
+
+  it("renders offline state when memoryStatus rejects (no daemon)", async () => {
+    memoryStatusMock.mockRejectedValueOnce(new Error("ipc closed"));
+    let utils: ReturnType<typeof render> | null = null;
+    await act(async () => {
+      utils = render(<Settings />);
+    });
+    await waitFor(() =>
+      expect(utils!.getByText(/Offline.*ipc closed/)).toBeDefined()
+    );
   });
 });

--- a/src/services/__tests__/ctxStore.test.ts
+++ b/src/services/__tests__/ctxStore.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+const invokeMock = vi.fn();
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: (...args: unknown[]) => invokeMock(...args),
+}));
+
+import { memoryStatus, isReady, type DaemonState } from "../ctxStore";
+
+describe("ctxStore", () => {
+  beforeEach(() => {
+    invokeMock.mockReset();
+  });
+
+  describe("memoryStatus", () => {
+    it("invokes the memory_status Tauri command with no args", async () => {
+      const state: DaemonState = { status: "starting" };
+      invokeMock.mockResolvedValueOnce(state);
+      const got = await memoryStatus();
+      expect(invokeMock).toHaveBeenCalledTimes(1);
+      expect(invokeMock).toHaveBeenCalledWith("memory_status");
+      expect(got).toEqual(state);
+    });
+
+    it("returns ready state with port numbers", async () => {
+      invokeMock.mockResolvedValueOnce({
+        status: "ready",
+        http_port: 51234,
+        wire_port: 51235,
+      } satisfies DaemonState);
+      const got = await memoryStatus();
+      expect(got.status).toBe("ready");
+      if (got.status === "ready") {
+        expect(got.http_port).toBe(51234);
+        expect(got.wire_port).toBe(51235);
+      }
+    });
+
+    it("returns offline state with reason", async () => {
+      invokeMock.mockResolvedValueOnce({
+        status: "offline",
+        reason: "ctxd did not become healthy: tcp connect refused",
+      } satisfies DaemonState);
+      const got = await memoryStatus();
+      expect(got.status).toBe("offline");
+      if (got.status === "offline") {
+        expect(got.reason).toContain("did not become healthy");
+      }
+    });
+
+    it("propagates Tauri command errors", async () => {
+      invokeMock.mockRejectedValueOnce(new Error("ipc closed"));
+      await expect(memoryStatus()).rejects.toThrow("ipc closed");
+    });
+  });
+
+  describe("isReady", () => {
+    it("narrows to the ready variant when status is ready", () => {
+      const state: DaemonState = { status: "ready", http_port: 1, wire_port: 2 };
+      expect(isReady(state)).toBe(true);
+      if (isReady(state)) {
+        // type-level check: this only compiles when narrowing works.
+        const _h: number = state.http_port;
+        const _w: number = state.wire_port;
+        void _h;
+        void _w;
+      }
+    });
+
+    it("returns false for non-ready states", () => {
+      expect(isReady({ status: "starting" })).toBe(false);
+      expect(isReady({ status: "offline", reason: "x" })).toBe(false);
+    });
+  });
+});

--- a/src/services/ctxStore.ts
+++ b/src/services/ctxStore.ts
@@ -1,0 +1,29 @@
+// Frontend wrapper for the ctxd memory subsystem. The Rust backend brokers
+// every ctxd call (see src-tauri/src/memory/) so this file only knows about
+// Tauri commands — never about ctxd's own HTTP/wire protocols. See
+// `tasks/ctxd-integration.md` for the full plan and `docs/decisions/`.
+//
+// v0.2.6 PR 1: only `memory_status` exists. Subsequent PRs add query/read/
+// write/subjects/related/subscribe.
+
+import { invoke } from "@tauri-apps/api/core";
+
+/**
+ * Daemon lifecycle states. Discriminated union — match on `status`.
+ *
+ * Mirrors Rust's `memory::DaemonState` (snake_case via serde tagged enum).
+ */
+export type DaemonState =
+  | { status: "starting" }
+  | { status: "ready"; http_port: number; wire_port: number }
+  | { status: "offline"; reason: string };
+
+/** Read the current daemon state. Cheap — pure memory lookup in Rust. */
+export async function memoryStatus(): Promise<DaemonState> {
+  return invoke<DaemonState>("memory_status");
+}
+
+/** Convenience: true if the daemon is up and accepting requests. */
+export function isReady(state: DaemonState): state is Extract<DaemonState, { status: "ready" }> {
+  return state.status === "ready";
+}


### PR DESCRIPTION
## Summary

Foundation PR for v0.2.6 — bundles [`keeprlabs/ctxd`](https://github.com/keeprlabs/ctxd) v0.3.0 as a Tauri sidecar binary inside `Keepr.app`. Spawned at app startup with random per-user loopback ports. End users see nothing — the DMG ships ctxd inside.

This is **PR 1 of 12** stacked into the `feat/ctxd-v0.2.6` integration branch. v0.2.6 ships forward-only writes alongside the existing markdown store; **no migration in this release**. See [`tasks/ctxd-integration.md`](./tasks/ctxd-integration.md) and [`docs/decisions/002-ctxd-lifecycle.md`](./docs/decisions/002-ctxd-lifecycle.md).

## What ships

**Build / distribution**
- `scripts/fetch-ctxd.ts` — downloads ctxd v0.3.0 tarball for the host triple (or `lipo`s both apple-darwin arches when `CTXD_TARGET=universal-apple-darwin`). Verifies SHA256 against the upstream checksum file. Idempotent. Wired into Tauri `beforeDev/Build` so dev and CI both fetch automatically.
- Binaries gitignored (~23 MB per arch). `tauri.conf.json` `bundle.externalBin` packs them into `Keepr.app` at bundle time.
- `release.yml` + `ci.yml` set `CTXD_TARGET=universal-apple-darwin` for the release path.

**Daemon lifecycle** (`src-tauri/src/memory/`)
- `daemon.rs` — spawn → `GET /health` poll on loopback → `Ready { http_port, wire_port }` / `Offline { reason }` state machine. Best-effort SIGTERM on window close. Pure-tokio HTTP/1.1 health probe (no reqwest).
- `ports.rs` — kernel-assigned ephemeral ports per user, persisted in app state.
- `mod.rs` — one Tauri command exposed: `memory_status`. The other `memory_*` commands land in PRs 2–12.

**Schema** (additive, non-breaking)
- Migration #9: `evidence_items.subject_path` for ctxd subject pointers (populated forward-only in PR 3).
- Migration #10: `team_members.ctxd_uuid` for UUID-based person IDs (`/keepr/people/{uuid}`). Slugs stay for human-readable URLs.

**Frontend**
- `src/services/ctxStore.ts` — thin TS wrapper with discriminated `DaemonState` union mirroring the Rust enum.
- `src/screens/Settings.tsx` — new "Memory layer" panel (status dot, port readout, manual Refresh). Read-only diagnostic; PR 7 owns the proper memory UI.

## What's NOT in this PR

These come in subsequent v0.2.6 PRs:
- PR 2: full Tauri command surface (`memory_query`, `memory_read`, `memory_write`, `memory_subjects`, `memory_related`, `memory_subscribe`)
- PR 3: subject schema + dual-write from `pipeline.ts` (forward-only writes alongside markdown)
- PR 4: GitHub adapter wiring (re-ingests history into `/work/github/**`)
- PRs 5–11: cmd+k palette, memory search screen, person page on ctxd, related panel, activity sidebar, pulse citations, onboarding banner
- PR 12: polish, eval, release

## Test plan

- [x] `npm run fetch-ctxd` downloads + verifies + extracts the ctxd binary; idempotent on re-run
- [x] `npx tsc --noEmit` — clean
- [x] `npm run test:run` — 239 frontend tests passing (4 new for Memory layer panel + ctxStore)
- [x] `cargo check` — clean
- [x] `cargo test --lib` — 8 Rust unit tests passing (all new — health probe, port allocation, daemon state)
- [x] `cargo build` — full debug build succeeds with externalBin reference
- [ ] Manual: `npx tauri dev` → Settings → "Memory layer" shows "Ready — http :XXXX · wire :XXXX" (reviewer to verify on their box)
- [ ] Manual: kill ctxd process externally → click Refresh → panel transitions to "Offline" with reason

## Related

- Plan: [`tasks/ctxd-integration.md`](./tasks/ctxd-integration.md)
- ADR: [`docs/decisions/002-ctxd-lifecycle.md`](./docs/decisions/002-ctxd-lifecycle.md)
- ctxd repo: https://github.com/keeprlabs/ctxd

🤖 Generated with [Claude Code](https://claude.com/claude-code)