### PR TITLE
chore: rotate Tauri updater pubkey to production key

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -35,7 +35,7 @@
       "endpoints": [
         "https://github.com/keeprlabs/keepr/releases/latest/download/latest.json"
       ],
-      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDU1ODVDMTY1RjVGOTBGMEIKUldRTEQvbjFaY0dGVlN5WWdzakxUcEszVllXR0plb1hJQXM3RmFzUHM4WEVCL3krdVJkSTNyYjIK",
+      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDE0NjREMkFBN0RBRDJFQjkKUldTNUxxMTlxdEprRktGU0hJbkdtd1o2Njh2RjBWcnc0OEhXYnBVUSsrVStYQjRHZm9lc1Z1enAK",
       "windows": {
         "installMode": "passive"
       }


### PR DESCRIPTION
## Summary

Replaces the dev-default Tauri updater pubkey (committed during PR #53) with the production key. After this lands, \`npm run release\` will ship real auto-update builds — the CI guard in \`release.yml\` already passes against this new key.

## Context

PR #53 committed a dev keypair so contributors could run \`npm run tauri:dev\` without a Rust panic. That keypair's private half lives on a local dev machine and was never used to sign any release. This PR swaps the embedded pubkey to the production key whose private half lives only in the \`TAURI_SIGNING_PRIVATE_KEY\` GitHub Actions secret.

| | Old (dev) | New (prod) |
|---|---|---|
| Comment | \`minisign public key: 5585C165F5F90F0B\` | \`minisign public key: 1464D2AA7DAD2EB9\` |
| Private key location | local dev machine | GitHub Actions secret only |
| Used to sign any release? | no | will sign all future releases |

## Test plan

- [x] \`cargo check\` passes with the new pubkey
- [x] CI guard in \`release.yml\` passes (it only fails if the dev key is still present)
- [ ] After merge: \`npm run release patch\` from \`main\` triggers a successful CI build that emits \`Keepr.app.tar.gz\`, \`.sig\`, and \`latest.json\`

## Blast radius

Zero. No release was ever cut from the dev pubkey, so no installed client trusts the dev key. The first release with auto-update enabled (the one we're about to cut after this merges) embeds the production pubkey from the start.