### PR TITLE
chore: rename ctxd milestone v0.2.6 → v0.2.7

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,11 +2,14 @@
 
 Recorded while building v1 so maintainers can audit what I changed and why.
 
-## v0.2.6 — ctxd memory layer (Unreleased)
+## v0.2.7 — ctxd memory layer (Unreleased)
 
 Bundling [`keeprlabs/ctxd`](https://github.com/keeprlabs/ctxd) v0.3.0 as
 Keepr's default memory substrate. Side-by-side with the existing markdown
-store (no migration in v0.2.6) — see `tasks/ctxd-integration.md`.
+store (no migration in v0.2.7) — see `tasks/ctxd-integration.md`.
+
+> NOTE: `v0.2.6` on `main` was the auto-updater release (Tauri v2 updater
+> plugin). This is a separate, independent milestone. Both ship.
 
 ### PR 1 — `feat/ctxd-bundle`
 

--- a/docs/decisions/002-ctxd-lifecycle.md
+++ b/docs/decisions/002-ctxd-lifecycle.md
@@ -9,7 +9,7 @@
 
 ## Context
 
-v0.2.6 introduces ctxd (`keeprlabs/ctxd`, Apache-2.0, Rust) as Keepr's memory substrate. ctxd is a single-binary daemon that exposes hybrid search, an event log, and an MCP server. Keepr's Rust backend will broker every ctxd call from the React frontend.
+v0.2.7 introduces ctxd (`keeprlabs/ctxd`, Apache-2.0, Rust) as Keepr's memory substrate. ctxd is a single-binary daemon that exposes hybrid search, an event log, and an MCP server. Keepr's Rust backend will broker every ctxd call from the React frontend.
 
 We need to decide:
 1. How ctxd is packaged (linked crate vs. sidecar binary).
@@ -69,7 +69,7 @@ The frontend can call `memory_status` at any time to read daemon state. When sta
 
 If the daemon crashes mid-session (detected via failed health probe or broken pipe on a command), the manager restarts it once with 1s backoff. A second consecutive failure flips state to `Offline` and surfaces a non-blocking banner: *"Memory layer offline — using last-known context. Click to retry."*
 
-The pre-ctxd markdown-tail path in `pipeline.ts` remains the fallback for v0.2.6, so the app is never fully broken.
+The pre-ctxd markdown-tail path in `pipeline.ts` remains the fallback for v0.2.7, so the app is never fully broken.
 
 ### 5. Upgrade story: `ctxd migrate` before `serve`
 
@@ -121,7 +121,7 @@ Rejected. Adds Rust toolchain as a runtime dependency for users, ~5 minute insta
 
 ### D. Vendor binaries committed to the repo
 
-Rejected for v0.2.6. Adds ~80 MB of binary commits per ctxd release. Fetch-on-build keeps the repo clean and works deterministically. Revisit if CI build times become a problem.
+Rejected for v0.2.7. Adds ~80 MB of binary commits per ctxd release. Fetch-on-build keeps the repo clean and works deterministically. Revisit if CI build times become a problem.
 
 ## Validation
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -276,7 +276,7 @@ ALTER TABLE team_members ADD COLUMN gitlab_username TEXT;
             version: 9,
             description: "evidence_subject_path",
             kind: MigrationKind::Up,
-            // v0.2.6: every evidence row gets a ctxd subject path so the UI
+            // v0.2.7: every evidence row gets a ctxd subject path so the UI
             // can pivot from a citation back to the canonical event. Column
             // is nullable; populated forward-only by the dual-write in PR 3.
             // Older rows stay NULL until the v0.4 markdown bulk-import lands.
@@ -289,7 +289,7 @@ CREATE INDEX IF NOT EXISTS idx_evidence_subject_path ON evidence_items(subject_p
             version: 10,
             description: "team_member_ctxd_uuid",
             kind: MigrationKind::Up,
-            // v0.2.6: stable UUID per person used as the ctxd subject ID
+            // v0.2.7: stable UUID per person used as the ctxd subject ID
             // (`/keepr/people/{uuid}`). Slugs stay for human-readable URLs
             // but are not used as ctxd subjects — see ADR-001 once written.
             // Populated lazily on first event write per person.
@@ -336,7 +336,7 @@ pub fn run() {
             // screen does not block on the health probe. Failures
             // transition the handle to Offline and surface via
             // `memory_status`; the rest of the app continues to work
-            // (markdown-tail path remains the v0.2.6 prompt builder).
+            // (markdown-tail path remains the v0.2.7 prompt builder).
             app.manage(memory::DaemonHandle::new());
             let app_handle = app.handle().clone();
             tauri::async_runtime::spawn(async move {

--- a/src-tauri/src/memory/mod.rs
+++ b/src-tauri/src/memory/mod.rs
@@ -3,7 +3,7 @@
 //! See `tasks/ctxd-integration.md` (overall plan) and
 //! `docs/decisions/002-ctxd-lifecycle.md` (lifecycle ADR).
 //!
-//! v0.2.6 PR 1 ships only the daemon lifecycle and a `memory_status` command.
+//! v0.2.7 PR 1 ships only the daemon lifecycle and a `memory_status` command.
 //! Subsequent PRs add `memory_query`, `memory_read`, `memory_write`, etc.
 
 pub mod daemon;

--- a/tasks/ctxd-integration.md
+++ b/tasks/ctxd-integration.md
@@ -1,6 +1,6 @@
 # ctxd as Keepr's Default Memory Store
 
-**Target releases:** v0.2.6 (foundation + visible wins), v0.3.0 (graph + dedup + external MCP), v0.4 (pipeline swap + bulk markdown import).
+**Target releases:** v0.2.7 (foundation + visible wins), v0.3.0 (graph + dedup + external MCP), v0.4 (pipeline swap + bulk markdown import).
 
 **Status:** plan locked, awaiting answers on three open questions before first PR (see end).
 
@@ -11,8 +11,8 @@
 1. **ctxd is `keeprlabs/ctxd`** — Rust, Apache-2.0, single binary, MCP-native, SQLite/FTS5/HNSW under the hood, GitHub + Gmail adapters already shipped upstream.
 2. **Tauri sidecar binary**, not linked crate. Lifecycle managed in `src-tauri/src/memory/daemon.rs`. Bound to loopback only.
 3. **Two SQLite files.** `keepr.db` keeps mutable operational state (sessions, secrets, followups, fetch_cache). `ctxd.db` is the append-only memory log. Linked via `source_uri` on `evidence_items`.
-4. **Side-by-side, no markdown migration in v0.2.6.** Forward-only writes. Markdown stays canonical. GitHub history is **re-ingested** by `ctxd-adapter-github` (not migrated). Bulk markdown → ctxd import lands in v0.4 once the schema is proven.
-5. **`pipeline.ts` stays on the markdown tail in v0.2.6.** The prompt-builder swap to `ctx_search` lands in v0.4 alongside markdown bulk import — when ctxd has real content. v0.2.6 ships UI value, not prompt changes.
+4. **Side-by-side, no markdown migration in v0.2.7.** Forward-only writes. Markdown stays canonical. GitHub history is **re-ingested** by `ctxd-adapter-github` (not migrated). Bulk markdown → ctxd import lands in v0.4 once the schema is proven.
+5. **`pipeline.ts` stays on the markdown tail in v0.2.7.** The prompt-builder swap to `ctx_search` lands in v0.4 alongside markdown bulk import — when ctxd has real content. v0.2.7 ships UI value, not prompt changes.
 6. **Embedder = `null` (FTS-only) by default.** Ollama / OpenAI opt-in lands in v0.3.0. BM25 over names, repo IDs, and ticket IDs covers ~80% of real queries.
 7. **Rust backend brokers all ctxd calls.** Frontend never touches ctxd directly. Capability tokens, ports, and error normalization live in Rust. Mirrors the `secrets.rs` pattern.
 8. **MCP is the LLM exposure surface.** Internal: `pipeline.ts` calls ctxd directly via the Tauri broker (no MCP roundtrip — it's the same process boundary). External: opt-in toggle lands in v0.3.0 with biscuit-scoped read-only access.
@@ -70,7 +70,7 @@ React component
         → ctxd daemon                   // SQLite
 ```
 
-Exposed Tauri commands (v0.2.6):
+Exposed Tauri commands (v0.2.7):
 
 | Command | Purpose |
 |---|---|
@@ -126,7 +126,7 @@ UI clicks an evidence row → reads `subject_path` → calls `memory_read(subjec
 
 ---
 
-## v0.2.6 — three weeks, twelve PRs
+## v0.2.7 — three weeks, twelve PRs
 
 Sized S (1-2d), M (3-5d). Two engineers parallel after foundation.
 
@@ -199,7 +199,7 @@ PR 1 ──▶ PR 2 ──┬──▶ PR 3 ──┬──▶ PR 7
 
 Two engineers can run weeks 2-3 in parallel: one on PR 3 → 7 → 10, the other on PR 4 → 8 → 9. PRs 5, 6, 11 fit between.
 
-### v0.2.6 ships with
+### v0.2.7 ships with
 
 - ctxd daemon as substrate, invisible to users.
 - Forward-only writes to ctxd from session boundaries.
@@ -212,7 +212,7 @@ Two engineers can run weeks 2-3 in parallel: one on PR 3 → 7 → 10, the other
 
 ## v0.3.0 — graph + dedup + external MCP
 
-Roughly 4 weeks after v0.2.6.
+Roughly 4 weeks after v0.2.7.
 
 1. **`feat/memory-graph`** — `ThreadGraph.tsx` upgrade using `ctx_related`, `ctx_entities`. Cross-source neighborhoods (PR ↔ ticket ↔ person ↔ session).
 2. **`feat/memory-decay-dedup`** — re-ranker wrapping `ctx_search` (`final = rrf * exp(-Δdays/60)`). Weekly consolidation pass writes `topic.consolidated` events with `supersedes: [...]` field. Materialized views ignore superseded events. Memory health Settings page.
@@ -274,7 +274,7 @@ Recommendation: build in CI. Eliminates large committed binaries, guarantees rep
 4. **GitHub re-ingest on first launch is slow for heavy users.** 10-30 min in background. *Mitigation:* progress banner; results in Memory Search arrive incrementally; user can dismiss banner and keep working.
 5. **Bundle size growth.** ctxd binary adds ~15-25 MB per platform. *Mitigation:* monitor DMG size in CI, alert if total grows past 80 MB net add.
 
-### Kill criteria (review at week 6 post-v0.2.6)
+### Kill criteria (review at week 6 post-v0.2.7)
 
 If any **two** hit, flip `app_config.memory.dualWrite=false` for everyone via remote config and ship v0.2.7 with rollback:
 
@@ -284,7 +284,7 @@ If any **two** hit, flip `app_config.memory.dualWrite=false` for everyone via re
 - Bundle size DMG net add > 80 MB.
 - User reports of lost data (any number > 0 — markdown is canonical so this should be impossible, but verify).
 
-A `app_config.memory.remoteKillSwitch` flag must exist from v0.2.6 day 1.
+A `app_config.memory.remoteKillSwitch` flag must exist from v0.2.7 day 1.
 
 ---
 
@@ -292,16 +292,16 @@ A `app_config.memory.remoteKillSwitch` flag must exist from v0.2.6 day 1.
 
 1. **Person subject IDs — UUID.** Path is `/keepr/people/{uuid}`. Display name written as `person.created` event field; rename writes a `person.updated` event without changing the subject. `team_members` table gains a `ctxd_uuid` column (migration #10) populated lazily on first event write per person. Slug stays for human-readable URLs in the UI, resolved via `team_members.slug → ctxd_uuid` lookup.
 
-2. **GitHub re-ingest default — on, with dismissible banner.** Background ingest starts on first v0.2.6 launch. Banner reads "Memory is rebuilding from your GitHub history. Search results will fill in over the next ~10 minutes." Dismissible. Status from `memory_status`. Settings → Memory → "Pause re-ingest" if a user wants to halt mid-flight.
+2. **GitHub re-ingest default — on, with dismissible banner.** Background ingest starts on first v0.2.7 launch. Banner reads "Memory is rebuilding from your GitHub history. Search results will fill in over the next ~10 minutes." Dismissible. Status from `memory_status`. Settings → Memory → "Pause re-ingest" if a user wants to halt mid-flight.
 
-3. **Federation — deferred to v0.5+.** Not surfaced in v0.2.6, v0.3.0, or v0.4. ctxd's federation primitives (peer, replicate, biscuit handoff) stay internal substrate. Revisit when the rest of the integration is proven.
+3. **Federation — deferred to v0.5+.** Not surfaced in v0.2.7, v0.3.0, or v0.4. ctxd's federation primitives (peer, replicate, biscuit handoff) stay internal substrate. Revisit when the rest of the integration is proven.
 
 ---
 
 ## What this plan saves vs. the original migration-first design
 
-- **One M-sized PR cut** (`feat/memory-migrate` removed from v0.2.6, deferred to v0.4).
-- **~3-5 days of engineering** in v0.2.6.
+- **One M-sized PR cut** (`feat/memory-migrate` removed from v0.2.7, deferred to v0.4).
+- **~3-5 days of engineering** in v0.2.7.
 - **A class of "import lost X" bugs** that would require markdown-walking edge-case code.
 - **Schema-rewrite risk** — by v0.4 we'll have lived with the schema in production for two releases.
 - **Decision-making weight** — we get to learn from real ctxd usage data before deciding what's worth importing. Some markdown sessions older than 90 days may never get queried, in which case we never bother importing them.


### PR DESCRIPTION
Avoids label collision with the auto-updater v0.2.6 already shipped on main. Branch refs unchanged. Cargo + vitest green.