### PR TITLE
feat(ctxd): subjects + dual-write + ADR-001 — PR 3 of v0.2.7

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,34 @@ store (no migration in v0.2.7) — see `tasks/ctxd-integration.md`.
 > NOTE: `v0.2.6` on `main` was the auto-updater release (Tauri v2 updater
 > plugin). This is a separate, independent milestone. Both ship.
 
+### PR 3 — `feat/memory-subjects`
+
+- New `src/services/ctxSubjects.ts` — canonical subject path builders for
+  every Keepr concept (person, session, topic, follow-up, status, evidence
+  bridge), `EVENT_TYPES` vocabulary, `SCHEMA_VERSION = 1`. Public contract;
+  see ADR-001.
+- New `docs/decisions/001-ctxd-subject-schema.md` — locks the schema.
+  UUIDs for person ids (not slugs); `/keepr/**` for Keepr-domain events,
+  `/work/**` reserved for adapter-owned namespaces, `/keepr/evidence/**`
+  as the bridge until upstream ctxd adapters ship.
+- New `db.ts ensureCtxdUuid(memberId)` lazy-populates `team_members.ctxd_uuid`
+  on first event-write per person.
+- `EvidenceItem.subject_path` populated on insert via `evidenceSubjectFor()`.
+  Migration #9 column finally has a writer; PR 10 will read it for
+  citation chips.
+- `pipeline.ts insertEvidence` now passes `subject_path` for every row.
+- `AppConfig.memory_dual_write` (default true) — kill switch; markdown
+  remains canonical regardless.
+- `memory.ts dualWriteSession()` — fire-and-forget after the markdown
+  write loop. Emits `session.completed`, `status.updated` (team_pulse /
+  weekly_update only), `person.fact` (per delta line, after lazy uuid
+  lookup), `topic.note` (per parsed topic). All under canonical subjects.
+  Promise.allSettled tolerates per-event offline failures with one warn
+  log.
+- 35 new vitest tests: 24 ctxSubjects (golden + validators + helpers),
+  11 dualWrite (kill switch, per-workflow events, person/topic emission,
+  failure tolerance, schema_version).
+
 ### PR 2 — `feat/memory-commands-skeleton`
 
 - Full Tauri command surface: `memory_query`, `memory_read`, `memory_write`,

--- a/docs/decisions/001-ctxd-subject-schema.md
+++ b/docs/decisions/001-ctxd-subject-schema.md
@@ -1,0 +1,138 @@
+# ADR-001: ctxd subject schema
+
+**Status:** accepted (2026-04-29)
+**Decides:** the canonical subject paths and event-type vocabulary Keepr writes into ctxd.
+**Related:** ADR-002 (lifecycle), `tasks/ctxd-integration.md`, `src/services/ctxSubjects.ts`.
+
+---
+
+## Context
+
+ctxd uses subject-based addressing — every event is filed under a hierarchical path like `/work/acme/notes/standup`. Subjects are forward-slash separated, glob-matchable, and **immutable in practice**: changing a subject after events have been written means rewriting history (or living with two parallel schemas).
+
+Keepr v0.2.7 begins dual-writing events into ctxd alongside the existing markdown store. This is the moment the subject layout becomes a public contract — once we've shipped a build that writes events under `/keepr/people/{uuid}`, every future read or query has to honour that path.
+
+We need to decide:
+1. The top-level namespace split (Keepr-owned vs adapter-owned).
+2. The path shape for each Keepr concept (people, sessions, topics, follow-ups, status, evidence).
+3. Which ID strategy to use per concept (slug vs UUID vs DB id).
+4. The canonical event-type vocabulary.
+5. A versioning policy for non-additive changes.
+
+## Decision
+
+### 1. Namespace split
+
+| Prefix | Owner | Purpose |
+|---|---|---|
+| `/keepr/**` | Keepr | Keepr-domain events: people, sessions, topics, follow-ups, status, bridge evidence. |
+| `/work/**` | adapters | Adapter-owned events from `ctxd-adapter-*` binaries (e.g. `/work/github/{owner}/{repo}/pulls/{n}`). |
+| `/keepr/evidence/{source}/...` | Keepr (bridge) | Evidence from sources that don't yet have a ctxd adapter (slack, jira, linear, gitlab; **also github until `ctxd-adapter-github` ships as a binary**). When the real adapter lands upstream, those events move to `/work/{source}/**` and a one-time consolidation rewrites references. |
+
+Keepr code never writes under `/work` — that's the adapter's namespace. Until upstream ships adapter binaries, our TS fetchers write to the bridge namespace via `memory_write`.
+
+### 2. Path shapes
+
+| Concept | Subject | ID strategy |
+|---|---|---|
+| Team member | `/keepr/people/{uuid}` | UUID (see §3) |
+| Session | `/keepr/sessions/{yyyy-mm-dd}/{workflow}/{slug}` | composite |
+| Topic | `/keepr/topics/{slug}` | kebab-case slug |
+| Follow-up | `/keepr/followups/{id}` | local DB integer id |
+| Status snapshot | `/keepr/status` | singleton |
+| Evidence (bridge) | `/keepr/evidence/{source}/{...natural id}` | source-defined |
+
+The full path-builder surface lives in `src/services/ctxSubjects.ts`. Every helper has a frozen golden test.
+
+### 3. Person IDs are UUIDs, not slugs
+
+`team_members.slug` is derived from `display_name` and changes whenever a person is renamed. Subjects don't change. If we used the slug, every rename would either:
+- silently leave events under the old subject and "lose" them on the new path, or
+- require rewriting history.
+
+UUIDs make the subject immutable. Display names live as event fields (`person.created`, `person.updated`).
+
+The UUID is generated lazily on the first event write per person and cached in `team_members.ctxd_uuid` (migration #10). Slugs continue to drive human-readable URLs in the UI; the slug→uuid lookup happens at write time.
+
+### 4. Canonical event-type vocabulary
+
+Defined in `EVENT_TYPES` (in `ctxSubjects.ts`):
+
+```
+PERSON_CREATED   = "person.created"
+PERSON_UPDATED   = "person.updated"
+PERSON_FACT      = "person.fact"
+SESSION_STARTED  = "session.started"
+SESSION_COMPLETED = "session.completed"
+SESSION_FAILED   = "session.failed"
+TOPIC_NOTE       = "topic.note"
+TOPIC_UPDATED    = "topic.updated"
+FOLLOWUP_OPENED  = "followup.opened"
+FOLLOWUP_CARRIED = "followup.carried"
+FOLLOWUP_RESOLVED = "followup.resolved"
+STATUS_UPDATED   = "status.updated"
+EVIDENCE_RECORDED = "evidence.recorded"
+```
+
+Lowercase, dot-separated, two segments: `{noun}.{verb}`. Each event carries a `schema_version` field; see §5.
+
+Adding a new type is fine. Renaming or removing one is a schema change.
+
+### 5. Versioning policy
+
+Every event written by Keepr carries a `schema_version: u32` field in its `data` payload. Current value: `1`.
+
+Bump rules:
+- **Additive change** (new event type, new optional data field): no version bump. Old readers ignore unknown fields.
+- **Breaking change** (rename event type, restructure subject path, remove a required field): bump `SCHEMA_VERSION` and write a new ADR documenting the migration. Reads must handle both old and new during the transition window.
+- **Subject-path changes**: a separate concern from schema version because they affect addressing, not payload shape. A subject rename requires a coordinated rewrite or living-with-two-schemas decision; see the v0.4 markdown-import plan for an example.
+
+We do not (yet) emit a `schema_version` event upgrader pipeline. v0.4 may add `ctxd migrate`-style schema rewrites; until then we live with whatever's in the log.
+
+### 6. Schema-lock-in surface
+
+The contract is the union of:
+- The path-builder functions in `src/services/ctxSubjects.ts`.
+- The `EVENT_TYPES` constants in the same file.
+- The golden test in `src/services/__tests__/ctxSubjects.test.ts`.
+
+Any change to these without a corresponding ADR update is a contract violation and must be reverted.
+
+## Consequences
+
+**Good:**
+- Subject paths are stable — renames don't invalidate history.
+- The `/keepr` vs `/work` split keeps Keepr from accidentally writing into adapter-owned namespaces.
+- The bridge namespace gives us a clean migration path when upstream adapters ship.
+- Every helper is golden-tested; future drift fails CI loudly.
+
+**Bad:**
+- UUIDs in URLs are uglier than slugs. Mitigated by keeping slugs in the UI URL layer; ctxd subjects are an internal addressing scheme.
+- Two namespaces for github (`/work/github/**` reserved, `/keepr/evidence/github/**` actually used today) means the v0.4 GitHub adapter ship needs a one-time consolidation pass. Acceptable cost; the adapter ships once.
+
+**Neutral:**
+- The schema_version field will be ignored for the foreseeable future. We just want it in the log so a v0.4 migrator has something to read.
+
+## Alternatives considered
+
+### A. Use slugs as person IDs
+
+Rejected. Renames break addressing. Every team has at least one person rename in its lifetime.
+
+### B. Use the integer DB id as person subject
+
+Rejected. Database ids are an implementation detail. If we ever rebuild from external sources or merge two installations (federation), ids collide and subjects break.
+
+### C. Mirror ctxd's recommended namespaces verbatim
+
+Rejected. ctxd's documentation suggests `/work/...` patterns, but those are adapter-owned. Keepr is its own domain; squatting on `/work` for Keepr-domain events would conflict with adapter writes.
+
+### D. Skip `schema_version` and rely on event-type names
+
+Rejected for a future-proofing reason. Event-type renames are sometimes necessary; carrying an explicit version makes the migration tractable.
+
+## Validation
+
+Frozen by `src/services/__tests__/ctxSubjects.test.ts`. Future changes that break the schema fail tests with a "renamed contract" diff.
+
+The first dual-write of real Keepr events lands in v0.2.7 PR 3 alongside this ADR. Any subject-path change after that PR ships requires a new ADR.

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -23,6 +23,11 @@ export interface TeamMember {
   jira_username: string | null;
   linear_username: string | null;
   slug: string;
+  /** v0.2.7+: stable UUID used as the ctxd subject id for this person
+   *  (`/keepr/people/{ctxd_uuid}`). Migration #10 added the column.
+   *  Lazily populated on first event-write per person via
+   *  `ensureCtxdUuid()`. Slugs are still used for human-readable URLs. */
+  ctxd_uuid?: string | null;
 }
 
 export interface SessionRow {
@@ -49,6 +54,11 @@ export interface EvidenceItem {
   actor_member_id: number | null;
   timestamp_at: string;
   content: string;
+  /** v0.2.7+: ctxd subject path for this evidence row (migration #9).
+   *  Null for rows inserted before v0.2.7, or for rows whose source
+   *  doesn't have a defined subject mapping in ctxSubjects.ts. PR 10
+   *  uses this to render citation chips. */
+  subject_path?: string | null;
 }
 
 // What Sonnet sees in the evidence JSON.
@@ -114,6 +124,11 @@ export interface AppConfig {
   onboarded_at: string | null;
   engineering_rubric: string | null;
   feature_flags: FeatureFlags;
+  /** v0.2.7+: when true, every markdown write also fires a fire-and-forget
+   *  ctxd event under the canonical subject path. Default true; flip to
+   *  false to disable the memory-layer dual-write entirely (kill switch).
+   *  Markdown remains canonical regardless. See ADR-001. */
+  memory_dual_write: boolean;
 }
 
 export interface PersonFact {
@@ -175,4 +190,5 @@ export const DEFAULT_CONFIG: AppConfig = {
   onboarded_at: null,
   engineering_rubric: null,
   feature_flags: DEFAULT_FEATURE_FLAGS,
+  memory_dual_write: true,
 };

--- a/src/services/__tests__/ctxSubjects.test.ts
+++ b/src/services/__tests__/ctxSubjects.test.ts
@@ -1,0 +1,182 @@
+// Golden tests for the ctxd subject schema. Every output path is
+// frozen — future renames will fail this test loudly.
+//
+// PUBLIC CONTRACT. See docs/decisions/001-ctxd-subject-schema.md.
+
+import { describe, expect, it } from "vitest";
+import {
+  personSubject,
+  sessionSubject,
+  topicSubject,
+  followupSubject,
+  statusSubject,
+  evidenceSubject,
+  evidenceSubjectFor,
+  EVENT_TYPES,
+  ROOT,
+  SCHEMA_VERSION,
+} from "../ctxSubjects";
+
+describe("ctxSubjects — golden paths", () => {
+  it("ROOT is /keepr", () => {
+    expect(ROOT).toBe("/keepr");
+  });
+
+  it("SCHEMA_VERSION is 1", () => {
+    expect(SCHEMA_VERSION).toBe(1);
+  });
+
+  it("personSubject", () => {
+    expect(personSubject("01900000-0000-7000-8000-000000000001")).toBe(
+      "/keepr/people/01900000-0000-7000-8000-000000000001"
+    );
+  });
+
+  it("sessionSubject", () => {
+    expect(sessionSubject("2026-04-28", "team_pulse", "weekly")).toBe(
+      "/keepr/sessions/2026-04-28/team_pulse/weekly"
+    );
+    expect(sessionSubject("2026-04-28", "one_on_one_prep", "priya-raman")).toBe(
+      "/keepr/sessions/2026-04-28/one_on_one_prep/priya-raman"
+    );
+  });
+
+  it("topicSubject", () => {
+    expect(topicSubject("auth-rewrite")).toBe("/keepr/topics/auth-rewrite");
+  });
+
+  it("followupSubject — accepts number or string", () => {
+    expect(followupSubject(42)).toBe("/keepr/followups/42");
+    expect(followupSubject("42")).toBe("/keepr/followups/42");
+  });
+
+  it("statusSubject is a singleton", () => {
+    expect(statusSubject()).toBe("/keepr/status");
+  });
+
+  it("evidenceSubject — github bridge", () => {
+    expect(evidenceSubject("github", ["acme", "web", "pulls", "42"])).toBe(
+      "/keepr/evidence/github/acme/web/pulls/42"
+    );
+  });
+
+  it("evidenceSubject — slack bridge", () => {
+    expect(evidenceSubject("slack", ["C123.456"])).toBe(
+      "/keepr/evidence/slack/C123.456"
+    );
+  });
+});
+
+describe("ctxSubjects — validators", () => {
+  it("personSubject rejects non-UUID", () => {
+    expect(() => personSubject("not-a-uuid")).toThrow(/UUID/);
+    expect(() => personSubject("")).toThrow(/UUID/);
+  });
+
+  it("sessionSubject rejects malformed date", () => {
+    expect(() => sessionSubject("April 28", "team_pulse", "weekly")).toThrow(/YYYY-MM-DD/);
+    expect(() => sessionSubject("2026-4-28", "team_pulse", "weekly")).toThrow(/YYYY-MM-DD/);
+  });
+
+  it("sessionSubject rejects empty workflow / slug", () => {
+    expect(() => sessionSubject("2026-04-28", "", "x")).toThrow(/workflow/);
+    expect(() => sessionSubject("2026-04-28", "team_pulse", "")).toThrow(/slug/);
+  });
+
+  it("sessionSubject rejects '/' in path parts", () => {
+    expect(() => sessionSubject("2026-04-28", "team/pulse", "x")).toThrow(/'\/'/);
+  });
+
+  it("topicSubject rejects empty / slashed slug", () => {
+    expect(() => topicSubject("")).toThrow(/topicSlug/);
+    expect(() => topicSubject("a/b")).toThrow(/'\/'/);
+  });
+
+  it("followupSubject rejects empty id", () => {
+    expect(() => followupSubject("")).toThrow(/empty id/);
+    expect(() => followupSubject("   ")).toThrow(/empty id/);
+  });
+
+  it("evidenceSubject rejects empty parts and '/' in parts", () => {
+    expect(() => evidenceSubject("github", [])).toThrow(/parts/);
+    expect(() => evidenceSubject("github", ["a", "b/c"])).toThrow(/invalid path part/);
+    expect(() => evidenceSubject("", ["a"])).toThrow(/source/);
+  });
+});
+
+describe("ctxSubjects — evidenceSubjectFor", () => {
+  it("github_pr extracts owner/repo/number from URL", () => {
+    expect(
+      evidenceSubjectFor(
+        "github_pr",
+        "ev-1",
+        "https://github.com/acme/web/pull/42"
+      )
+    ).toBe("/keepr/evidence/github/acme/web/pulls/42/ev-1");
+  });
+
+  it("github_review same shape with reviews kind", () => {
+    expect(
+      evidenceSubjectFor(
+        "github_review",
+        "ev-2",
+        "https://github.com/acme/web/pull/42#pullrequestreview-99"
+      )
+    ).toBe("/keepr/evidence/github/acme/web/reviews/42/ev-2");
+  });
+
+  it("gitlab_mr extracts project path and MR number", () => {
+    expect(
+      evidenceSubjectFor(
+        "gitlab_mr",
+        "ev-3",
+        "https://gitlab.com/group/project/-/merge_requests/7"
+      )
+    ).toBe("/keepr/evidence/gitlab/group/project/mrs/7/ev-3");
+  });
+
+  it("slack_message escapes / in source_id", () => {
+    expect(evidenceSubjectFor("slack_message", "C123/456.789", null)).toBe(
+      "/keepr/evidence/slack/C123_456.789"
+    );
+  });
+
+  it("jira and linear use kind segment", () => {
+    expect(evidenceSubjectFor("jira_issue", "PROJ-123", null)).toBe(
+      "/keepr/evidence/jira/issues/PROJ-123"
+    );
+    expect(evidenceSubjectFor("linear_comment", "abc-def", null)).toBe(
+      "/keepr/evidence/linear/comments/abc-def"
+    );
+  });
+
+  it("returns null for unknown sources", () => {
+    expect(evidenceSubjectFor("unknown_source", "x", null)).toBeNull();
+  });
+
+  it("returns null when github URL is malformed", () => {
+    expect(evidenceSubjectFor("github_pr", "ev-x", "https://example.com/bad")).toBeNull();
+  });
+});
+
+describe("ctxSubjects — EVENT_TYPES", () => {
+  it("freezes the canonical event-type set", () => {
+    // Golden snapshot — adding a new type is fine; renaming or
+    // removing one is a schema change requiring an ADR update.
+    expect(EVENT_TYPES).toEqual({
+      PERSON_CREATED: "person.created",
+      PERSON_UPDATED: "person.updated",
+      PERSON_FACT: "person.fact",
+      SESSION_STARTED: "session.started",
+      SESSION_COMPLETED: "session.completed",
+      SESSION_FAILED: "session.failed",
+      TOPIC_NOTE: "topic.note",
+      TOPIC_UPDATED: "topic.updated",
+      FOLLOWUP_OPENED: "followup.opened",
+      FOLLOWUP_CARRIED: "followup.carried",
+      FOLLOWUP_RESOLVED: "followup.resolved",
+      STATUS_UPDATED: "status.updated",
+      EVIDENCE_RECORDED: "evidence.recorded",
+    });
+  });
+});

--- a/src/services/__tests__/memoryDualWrite.test.ts
+++ b/src/services/__tests__/memoryDualWrite.test.ts
@@ -1,0 +1,207 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import type { TeamMember } from "../../lib/types";
+import { DEFAULT_CONFIG } from "../../lib/types";
+
+const memoryWriteMock = vi.fn();
+const ensureCtxdUuidMock = vi.fn();
+const getConfigMock = vi.fn();
+const logWarnMock = vi.fn();
+
+vi.mock("../ctxStore", () => ({
+  memoryWrite: (...a: unknown[]) => memoryWriteMock(...a),
+}));
+
+vi.mock("../db", () => ({
+  ensureCtxdUuid: (...a: unknown[]) => ensureCtxdUuidMock(...a),
+  getConfig: (...a: unknown[]) => getConfigMock(...a),
+}));
+
+vi.mock("@tauri-apps/plugin-log", () => ({
+  warn: (...a: unknown[]) => logWarnMock(...a),
+  info: vi.fn(),
+}));
+
+import { dualWriteSession } from "../memory";
+
+const member = (id: number, name: string, slug: string): TeamMember => ({
+  id,
+  display_name: name,
+  github_handle: null,
+  gitlab_username: null,
+  slack_user_id: null,
+  jira_username: null,
+  linear_username: null,
+  slug,
+  ctxd_uuid: null,
+});
+
+const baseArgs = {
+  workflow: "team_pulse" as const,
+  targetSlug: null,
+  targetDisplayName: null,
+  members: [member(1, "Priya Raman", "priya-raman")],
+  visibleMarkdown: "# Team Pulse\n\nShipped feature x and unblocked Tomás.",
+  byPerson: new Map<number, Array<{ personId: number; line: string }>>(),
+  topics: [] as Array<{ name: string; bullets: string[] }>,
+  dateStamp: "2026-04-29",
+  timeRange: { start: "2026-04-22", end: "2026-04-29" },
+  sessionFile: "/tmp/keepr/sessions/2026-04-29-team-pulse.md",
+};
+
+beforeEach(() => {
+  memoryWriteMock.mockReset();
+  ensureCtxdUuidMock.mockReset();
+  getConfigMock.mockReset();
+  logWarnMock.mockReset();
+  memoryWriteMock.mockResolvedValue("01900000-0000-7000-8000-000000000000");
+  ensureCtxdUuidMock.mockResolvedValue("01900000-0000-7000-8000-000000000001");
+  getConfigMock.mockResolvedValue({ ...DEFAULT_CONFIG, memory_dual_write: true });
+});
+
+describe("dualWriteSession — kill switch", () => {
+  it("writes nothing when memory_dual_write is false", async () => {
+    getConfigMock.mockResolvedValueOnce({
+      ...DEFAULT_CONFIG,
+      memory_dual_write: false,
+    });
+    await dualWriteSession({ ...baseArgs });
+    expect(memoryWriteMock).not.toHaveBeenCalled();
+    expect(ensureCtxdUuidMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("dualWriteSession — per-workflow events", () => {
+  it("team_pulse emits session.completed AND status.updated", async () => {
+    await dualWriteSession({ ...baseArgs, workflow: "team_pulse" });
+    const calls = memoryWriteMock.mock.calls;
+    const types = calls.map((c) => c[1]);
+    expect(types).toContain("session.completed");
+    expect(types).toContain("status.updated");
+
+    const sessionCall = calls.find((c) => c[1] === "session.completed")!;
+    expect(sessionCall[0]).toBe("/keepr/sessions/2026-04-29/team_pulse/team-pulse");
+    expect(sessionCall[2].schema_version).toBe(1);
+    expect(sessionCall[2].workflow).toBe("team_pulse");
+
+    const statusCall = calls.find((c) => c[1] === "status.updated")!;
+    expect(statusCall[0]).toBe("/keepr/status");
+  });
+
+  it("weekly_update emits both session.completed AND status.updated", async () => {
+    await dualWriteSession({ ...baseArgs, workflow: "weekly_update" });
+    const types = memoryWriteMock.mock.calls.map((c) => c[1]);
+    expect(types).toContain("session.completed");
+    expect(types).toContain("status.updated");
+  });
+
+  it("one_on_one_prep emits ONLY session.completed (no status update)", async () => {
+    await dualWriteSession({
+      ...baseArgs,
+      workflow: "one_on_one_prep",
+      targetSlug: "priya-raman",
+      targetDisplayName: "Priya Raman",
+    });
+    const types = memoryWriteMock.mock.calls.map((c) => c[1]);
+    expect(types).toContain("session.completed");
+    expect(types).not.toContain("status.updated");
+
+    const sessionCall = memoryWriteMock.mock.calls.find(
+      (c) => c[1] === "session.completed"
+    )!;
+    expect(sessionCall[0]).toBe(
+      "/keepr/sessions/2026-04-29/one_on_one_prep/1on1-priya-raman"
+    );
+  });
+});
+
+describe("dualWriteSession — person facts", () => {
+  it("emits one person.fact event per delta line, looking up ctxd_uuid lazily", async () => {
+    const byPerson = new Map<number, Array<{ personId: number; line: string }>>();
+    byPerson.set(1, [
+      { personId: 1, line: "Shipped feature x" },
+      { personId: 1, line: "Reviewed 4 PRs" },
+    ]);
+    await dualWriteSession({ ...baseArgs, byPerson });
+
+    expect(ensureCtxdUuidMock).toHaveBeenCalledWith(1);
+    const personCalls = memoryWriteMock.mock.calls.filter((c) => c[1] === "person.fact");
+    expect(personCalls).toHaveLength(2);
+    expect(personCalls[0][0]).toBe(
+      "/keepr/people/01900000-0000-7000-8000-000000000001"
+    );
+    expect(personCalls[0][2].line).toBe("Shipped feature x");
+    expect(personCalls[1][2].line).toBe("Reviewed 4 PRs");
+  });
+
+  it("skips members whose ctxd_uuid lookup fails (logs warning, no event)", async () => {
+    ensureCtxdUuidMock.mockRejectedValueOnce(new Error("db gone"));
+    const byPerson = new Map<number, Array<{ personId: number; line: string }>>();
+    byPerson.set(1, [{ personId: 1, line: "ought to fail" }]);
+    await dualWriteSession({ ...baseArgs, byPerson });
+
+    const personCalls = memoryWriteMock.mock.calls.filter((c) => c[1] === "person.fact");
+    expect(personCalls).toHaveLength(0);
+    expect(logWarnMock).toHaveBeenCalled();
+  });
+
+  it("skips deltas referencing unknown member ids (no member in args.members)", async () => {
+    const byPerson = new Map<number, Array<{ personId: number; line: string }>>();
+    byPerson.set(999, [{ personId: 999, line: "ghost member" }]);
+    await dualWriteSession({ ...baseArgs, byPerson });
+
+    expect(ensureCtxdUuidMock).not.toHaveBeenCalled();
+    const personCalls = memoryWriteMock.mock.calls.filter((c) => c[1] === "person.fact");
+    expect(personCalls).toHaveLength(0);
+  });
+});
+
+describe("dualWriteSession — topics", () => {
+  it("emits one topic.note event per topic with slugged subject", async () => {
+    const topics = [
+      { name: "Auth Rewrite", bullets: ["RFC merged", "Tests passing"] },
+      { name: "K8s Migration", bullets: ["Pilot launched"] },
+    ];
+    await dualWriteSession({ ...baseArgs, topics });
+
+    const topicCalls = memoryWriteMock.mock.calls.filter((c) => c[1] === "topic.note");
+    expect(topicCalls).toHaveLength(2);
+    expect(topicCalls[0][0]).toBe("/keepr/topics/auth-rewrite");
+    expect(topicCalls[0][2].name).toBe("Auth Rewrite");
+    expect(topicCalls[0][2].bullets).toEqual(["RFC merged", "Tests passing"]);
+    expect(topicCalls[1][0]).toBe("/keepr/topics/k8s-migration");
+  });
+});
+
+describe("dualWriteSession — failure tolerance", () => {
+  it("logs (does not throw) when memoryWrite rejects for individual events", async () => {
+    memoryWriteMock.mockRejectedValueOnce(new Error("offline"));
+    memoryWriteMock.mockResolvedValueOnce("ok-session");
+
+    // team_pulse: 2 writes (session + status). Make the first reject, second succeed.
+    await expect(dualWriteSession({ ...baseArgs })).resolves.toBeUndefined();
+    expect(logWarnMock).toHaveBeenCalledWith(
+      expect.stringContaining("dual-write")
+    );
+  });
+
+  it("does not throw when ALL writes reject", async () => {
+    memoryWriteMock.mockRejectedValue(new Error("offline"));
+    await expect(dualWriteSession({ ...baseArgs })).resolves.toBeUndefined();
+    expect(logWarnMock).toHaveBeenCalled();
+  });
+});
+
+describe("dualWriteSession — schema_version", () => {
+  it("every event payload includes schema_version=1", async () => {
+    const byPerson = new Map<number, Array<{ personId: number; line: string }>>();
+    byPerson.set(1, [{ personId: 1, line: "x" }]);
+    await dualWriteSession({
+      ...baseArgs,
+      byPerson,
+      topics: [{ name: "T", bullets: ["b"] }],
+    });
+    for (const [, , data] of memoryWriteMock.mock.calls) {
+      expect(data.schema_version).toBe(1);
+    }
+  });
+});

--- a/src/services/ctxSubjects.ts
+++ b/src/services/ctxSubjects.ts
@@ -1,0 +1,204 @@
+// Canonical ctxd subject paths and event types for Keepr's domain.
+//
+// **PUBLIC CONTRACT.** Once events are written under these paths, renaming
+// means rewriting history. Treat this file like an API surface — additive
+// changes only. See `docs/decisions/001-ctxd-subject-schema.md` for the
+// versioning policy and `tasks/ctxd-integration.md` for the broader plan.
+//
+// All functions are pure and total. The golden test in
+// `__tests__/ctxSubjects.test.ts` freezes every output path; future
+// renames will fail loudly.
+
+/** Schema version embedded in every event we write. Bump when the
+ *  subject layout or event-type set changes in a non-additive way. */
+export const SCHEMA_VERSION = 1;
+
+/** Top-level subject namespaces.
+ *  - `/keepr/**` — Keepr-owned events (people, sessions, topics, ...).
+ *  - `/work/**` — adapter-owned events (e.g. ctxd-adapter-github writes
+ *    `/work/github/{owner}/{repo}/pulls/{n}`). We never write under
+ *    `/work` from Keepr code; that's the adapter's namespace.
+ *  - `/keepr/evidence/{source}/...` — bridge namespace for sources where
+ *    no upstream ctxd adapter exists yet (slack, jira, linear, gitlab).
+ *    When the real adapter ships, those move to `/work/{source}/...` and
+ *    a one-time consolidation rewrites references. */
+export const ROOT = "/keepr";
+
+// ---------- Person ------------------------------------------------------
+
+/** `/keepr/people/{uuid}` — the team member's stable ctxd subject.
+ *
+ *  IDs are UUIDs (not slugs) because slugs change on rename and ctxd
+ *  subjects are immutable in practice. The UUID is generated lazily on
+ *  first event write per person and cached in `team_members.ctxd_uuid`
+ *  (migration #10). The display name is carried as a `person.created`
+ *  / `person.updated` event field, NOT in the subject. */
+export function personSubject(ctxdUuid: string): string {
+  assertUuid(ctxdUuid, "personSubject");
+  return `${ROOT}/people/${ctxdUuid}`;
+}
+
+// ---------- Session ----------------------------------------------------
+
+/** `/keepr/sessions/{yyyy-mm-dd}/{workflow}/{slug}` */
+export function sessionSubject(
+  isoDate: string,
+  workflow: string,
+  slug: string
+): string {
+  assertDateStamp(isoDate);
+  assertNonEmpty(workflow, "workflow");
+  assertNonEmpty(slug, "slug");
+  return `${ROOT}/sessions/${isoDate}/${workflow}/${slug}`;
+}
+
+// ---------- Topic ------------------------------------------------------
+
+/** `/keepr/topics/{slug}` — slug is the human-readable topic identifier
+ *  (kebab-case). Topics are renameable in principle, but in practice
+ *  Keepr derives slugs from headings and rarely renames. */
+export function topicSubject(topicSlug: string): string {
+  assertNonEmpty(topicSlug, "topicSlug");
+  return `${ROOT}/topics/${topicSlug}`;
+}
+
+// ---------- Follow-up --------------------------------------------------
+
+/** `/keepr/followups/{id}` — `id` is the local DB integer id as a string.
+ *  Stable for the life of the row (we never renumber). */
+export function followupSubject(id: number | string): string {
+  const s = String(id).trim();
+  if (!s) throw new Error("followupSubject: empty id");
+  return `${ROOT}/followups/${s}`;
+}
+
+// ---------- Status snapshot --------------------------------------------
+
+/** `/keepr/status` — the singleton "latest team status" subject. Each
+ *  team_pulse / weekly_update writes a `status.updated` event here. */
+export function statusSubject(): string {
+  return `${ROOT}/status`;
+}
+
+// ---------- Evidence (bridge namespace) --------------------------------
+
+/** `/keepr/evidence/{source}/{...rest}` — for sources that don't yet
+ *  have a ctxd adapter (slack, jira, linear, gitlab). `parts` is the
+ *  natural identifier hierarchy for that source. Examples:
+ *
+ *    evidenceSubject("slack", ["channel-id", "ts"])
+ *      → "/keepr/evidence/slack/channel-id/ts"
+ *
+ *    evidenceSubject("github", ["acme", "web", "pulls", "42"])
+ *      → "/keepr/evidence/github/acme/web/pulls/42"
+ *      (until ctxd-adapter-github ships and we move to /work/github/**)
+ */
+export function evidenceSubject(source: string, parts: string[]): string {
+  assertNonEmpty(source, "source");
+  if (!parts.length) throw new Error("evidenceSubject: parts must be non-empty");
+  for (const p of parts) {
+    if (!p || p.includes("/")) {
+      throw new Error(`evidenceSubject: invalid path part: ${JSON.stringify(p)}`);
+    }
+  }
+  return `${ROOT}/evidence/${source}/${parts.join("/")}`;
+}
+
+/** Convenience for the existing `EvidenceItem.source` enum + the
+ *  natural id columns. Returns `null` for sources we don't know how
+ *  to subject yet (caller should leave `subject_path` NULL). */
+export function evidenceSubjectFor(
+  source: string,
+  sourceId: string,
+  sourceUrl: string | null
+): string | null {
+  // ctxd-adapter-github (when it ships) will own /work/github/**. Until
+  // then we use the bridge namespace.
+  switch (source) {
+    case "github_pr":
+    case "github_review": {
+      // source_url shape: https://github.com/{owner}/{repo}/pull/{n}[#review-...]
+      // We extract owner/repo/n; everything else collapses to a single
+      // id segment to keep paths sane.
+      const m = sourceUrl?.match(/github\.com\/([^/]+)\/([^/]+)\/(?:pull|issues)\/(\d+)/);
+      if (!m) return null;
+      const [_, owner, repo, n] = m;
+      const kind = source === "github_pr" ? "pulls" : "reviews";
+      return evidenceSubject("github", [owner, repo, kind, n, sourceId]);
+    }
+    case "gitlab_mr":
+    case "gitlab_review": {
+      const m = sourceUrl?.match(/\/([^/]+\/[^/]+)\/-\/merge_requests\/(\d+)/);
+      if (!m) return null;
+      const [_, project, n] = m;
+      const kind = source === "gitlab_mr" ? "mrs" : "reviews";
+      return evidenceSubject("gitlab", [...project.split("/"), kind, n, sourceId]);
+    }
+    case "slack_message": {
+      // sourceId carries the channel.ts; that's enough for uniqueness.
+      const safeId = sourceId.replace(/\//g, "_");
+      return evidenceSubject("slack", [safeId]);
+    }
+    case "jira_issue":
+    case "jira_comment": {
+      const safeId = sourceId.replace(/\//g, "_");
+      const kind = source === "jira_issue" ? "issues" : "comments";
+      return evidenceSubject("jira", [kind, safeId]);
+    }
+    case "linear_issue":
+    case "linear_comment": {
+      const safeId = sourceId.replace(/\//g, "_");
+      const kind = source === "linear_issue" ? "issues" : "comments";
+      return evidenceSubject("linear", [kind, safeId]);
+    }
+    default:
+      return null;
+  }
+}
+
+// ---------- Event types -------------------------------------------------
+
+export const EVENT_TYPES = {
+  // Person.
+  PERSON_CREATED: "person.created",
+  PERSON_UPDATED: "person.updated",
+  PERSON_FACT: "person.fact",
+  // Session.
+  SESSION_STARTED: "session.started",
+  SESSION_COMPLETED: "session.completed",
+  SESSION_FAILED: "session.failed",
+  // Topic.
+  TOPIC_NOTE: "topic.note",
+  TOPIC_UPDATED: "topic.updated",
+  // Follow-up.
+  FOLLOWUP_OPENED: "followup.opened",
+  FOLLOWUP_CARRIED: "followup.carried",
+  FOLLOWUP_RESOLVED: "followup.resolved",
+  // Status.
+  STATUS_UPDATED: "status.updated",
+  // Evidence (bridge).
+  EVIDENCE_RECORDED: "evidence.recorded",
+} as const;
+
+export type EventType = (typeof EVENT_TYPES)[keyof typeof EVENT_TYPES];
+
+// ---------- Validators -------------------------------------------------
+
+const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+function assertUuid(v: string, where: string): void {
+  if (!UUID_REGEX.test(v)) {
+    throw new Error(`${where}: not a valid UUID: ${JSON.stringify(v)}`);
+  }
+}
+
+function assertDateStamp(v: string): void {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(v)) {
+    throw new Error(`sessionSubject: date must be YYYY-MM-DD, got ${JSON.stringify(v)}`);
+  }
+}
+
+function assertNonEmpty(v: string, name: string): void {
+  if (!v || !v.trim()) throw new Error(`${name} must be non-empty`);
+  if (v.includes("/")) throw new Error(`${name} must not contain '/': ${JSON.stringify(v)}`);
+}

--- a/src/services/db.ts
+++ b/src/services/db.ts
@@ -230,6 +230,38 @@ export async function deleteSession(id: number): Promise<void> {
   await d.execute("DELETE FROM sessions WHERE id = ?", [id]);
 }
 
+/**
+ * v0.2.7+: lazily populate `team_members.ctxd_uuid` so the person has a
+ * stable ctxd subject id (`/keepr/people/{uuid}`). Returns the existing
+ * uuid if set, or generates one via `crypto.randomUUID()` and persists.
+ *
+ * Idempotent under concurrent calls — the `UNIQUE` index on `ctxd_uuid`
+ * keeps races safe; the worst-case is two callers both generate, one
+ * insert wins, the loser re-reads.
+ */
+export async function ensureCtxdUuid(memberId: number): Promise<string> {
+  const d = await db();
+  const rows = await d.select<Array<{ ctxd_uuid: string | null }>>(
+    "SELECT ctxd_uuid FROM team_members WHERE id = ?",
+    [memberId]
+  );
+  if (!rows.length) {
+    throw new Error(`ensureCtxdUuid: no team_member with id=${memberId}`);
+  }
+  if (rows[0].ctxd_uuid) return rows[0].ctxd_uuid;
+  const uuid = crypto.randomUUID();
+  await d.execute(
+    "UPDATE team_members SET ctxd_uuid = ? WHERE id = ? AND ctxd_uuid IS NULL",
+    [uuid, memberId]
+  );
+  // Re-read to handle the rare race where two callers both generated.
+  const after = await d.select<Array<{ ctxd_uuid: string | null }>>(
+    "SELECT ctxd_uuid FROM team_members WHERE id = ?",
+    [memberId]
+  );
+  return after[0].ctxd_uuid ?? uuid;
+}
+
 // ---- Evidence ------------------------------------------------------------
 
 export async function insertEvidence(
@@ -240,7 +272,7 @@ export async function insertEvidence(
   const out: EvidenceItem[] = [];
   for (const it of items) {
     const res = await d.execute(
-      "INSERT INTO evidence_items(session_id, source, source_url, source_id, actor_member_id, timestamp_at, content) VALUES(?,?,?,?,?,?,?)",
+      "INSERT INTO evidence_items(session_id, source, source_url, source_id, actor_member_id, timestamp_at, content, subject_path) VALUES(?,?,?,?,?,?,?,?)",
       [
         session_id,
         it.source,
@@ -249,6 +281,7 @@ export async function insertEvidence(
         it.actor_member_id,
         it.timestamp_at,
         it.content,
+        it.subject_path ?? null,
       ]
     );
     out.push({ id: res.lastInsertId as number, session_id, ...it });

--- a/src/services/memory.ts
+++ b/src/services/memory.ts
@@ -16,6 +16,17 @@ import {
   writeFileAtomic,
 } from "./fsio";
 import type { TeamMember, WorkflowType } from "../lib/types";
+import { getConfig, ensureCtxdUuid } from "./db";
+import { memoryWrite } from "./ctxStore";
+import {
+  EVENT_TYPES,
+  SCHEMA_VERSION,
+  personSubject,
+  sessionSubject,
+  statusSubject,
+  topicSubject,
+} from "./ctxSubjects";
+import { warn as logWarn } from "@tauri-apps/plugin-log";
 
 const LOCK_FILE = ".keepr.lock";
 
@@ -317,6 +328,26 @@ export async function writeMemory(args: {
       }
     }
 
+    // ---- ctxd dual-write (fire-and-forget) ----
+    // Markdown is canonical; ctxd is a derived index. We don't await
+    // the ctxd writes — failures get logged, the session result is
+    // returned immediately. Behind app_config.memory_dual_write so
+    // operators can flip it off if the daemon misbehaves.
+    void dualWriteSession({
+      workflow: args.workflow,
+      targetSlug: args.targetSlug,
+      targetDisplayName: args.targetDisplayName,
+      members: args.members,
+      visibleMarkdown,
+      byPerson,
+      topics,
+      dateStamp,
+      timeRange: args.timeRange,
+      sessionFile,
+    }).catch((err) =>
+      logWarn(`memory dual-write failed: ${err instanceof Error ? err.message : String(err)}`)
+    );
+
     return sessionFile;
   } finally {
     await releaseLock(lockPath);
@@ -385,4 +416,122 @@ async function appendMemoryFile(
   const seed = prior ?? opts.header ?? "";
   const next = seed.endsWith("\n") || seed === "" ? seed + block : seed + "\n" + block;
   await conflictSafeWrite(path, next);
+}
+
+
+// ---------- ctxd dual-write (v0.2.7+) -------------------------------------
+//
+// Mirrors every markdown write into a ctxd event. Markdown is canonical;
+// these writes are fire-and-forget. Gated by `app_config.memory_dual_write`
+// (default true). Daemon offline = no writes happen, no session-flow impact.
+// See ADR-001 (subject schema) and ADR-002 (lifecycle).
+
+interface DualWriteArgs {
+  workflow: WorkflowType;
+  targetSlug: string | null;
+  targetDisplayName: string | null;
+  members: TeamMember[];
+  visibleMarkdown: string;
+  byPerson: Map<number, MemoryDelta[]>;
+  topics: ParsedTopic[];
+  dateStamp: string;
+  timeRange: { start: string; end: string };
+  sessionFile: string;
+}
+
+export async function dualWriteSession(args: DualWriteArgs): Promise<void> {
+  const cfg = await getConfig();
+  if (!cfg.memory_dual_write) return;
+
+  const sessionSlug = sessionSlugFor(args.workflow, args.targetSlug);
+  const writes: Array<Promise<unknown>> = [];
+
+  writes.push(
+    memoryWrite(
+      sessionSubject(args.dateStamp, args.workflow, sessionSlug),
+      EVENT_TYPES.SESSION_COMPLETED,
+      {
+        schema_version: SCHEMA_VERSION,
+        workflow: args.workflow,
+        target_display_name: args.targetDisplayName,
+        time_range: args.timeRange,
+        session_file: args.sessionFile,
+        summary: firstFewSentences(args.visibleMarkdown),
+      }
+    )
+  );
+
+  if (args.workflow === "team_pulse" || args.workflow === "weekly_update") {
+    writes.push(
+      memoryWrite(statusSubject(), EVENT_TYPES.STATUS_UPDATED, {
+        schema_version: SCHEMA_VERSION,
+        workflow: args.workflow,
+        time_range: args.timeRange,
+        summary: firstFewSentences(args.visibleMarkdown),
+      })
+    );
+  }
+
+  for (const [personId, deltas] of args.byPerson) {
+    const member = args.members.find((m) => m.id === personId);
+    if (!member) continue;
+    let uuid: string;
+    try {
+      uuid = await ensureCtxdUuid(personId);
+    } catch (err) {
+      logWarn(`dual-write: ensureCtxdUuid(${personId}) failed: ${String(err)}`);
+      continue;
+    }
+    const subject = personSubject(uuid);
+    for (const d of deltas) {
+      writes.push(
+        memoryWrite(subject, EVENT_TYPES.PERSON_FACT, {
+          schema_version: SCHEMA_VERSION,
+          display_name: member.display_name,
+          slug: member.slug,
+          line: d.line,
+          workflow: args.workflow,
+          date: args.dateStamp,
+        })
+      );
+    }
+  }
+
+  for (const topic of args.topics) {
+    const topicSlug = slugify(topic.name);
+    writes.push(
+      memoryWrite(topicSubject(topicSlug), EVENT_TYPES.TOPIC_NOTE, {
+        schema_version: SCHEMA_VERSION,
+        name: topic.name,
+        bullets: topic.bullets,
+        workflow: args.workflow,
+        date: args.dateStamp,
+      })
+    );
+  }
+
+  const results = await Promise.allSettled(writes);
+  const failures = results.filter((r) => r.status === "rejected");
+  if (failures.length) {
+    logWarn(
+      `memory dual-write: ${failures.length}/${results.length} events did not land — daemon offline?`
+    );
+  }
+}
+
+function sessionSlugFor(workflow: WorkflowType, targetSlug: string | null): string {
+  switch (workflow) {
+    case "team_pulse":
+      return "team-pulse";
+    case "one_on_one_prep":
+      return `1on1-${targetSlug || "engineer"}`;
+    case "weekly_update":
+      return "weekly-update";
+    case "perf_evaluation":
+      return `perf-eval-${targetSlug || "engineer"}`;
+    case "promo_readiness":
+      return `promo-readiness-${targetSlug || "engineer"}`;
+    default:
+      return workflow;
+  }
 }

--- a/src/services/pipeline.ts
+++ b/src/services/pipeline.ts
@@ -43,6 +43,7 @@ import { fetchProjectActivity, type FetchedJiraIssue } from "./jira";
 import { fetchTeamActivity, type FetchedLinearIssue } from "./linear";
 import { getProvider, setCustomConfig } from "./llm";
 import { writeMemory, readMemoryContext } from "./memory";
+import { evidenceSubjectFor } from "./ctxSubjects";
 import { throwIfAborted, isAbortError } from "../lib/abort";
 import { info as logInfo, warn as logWarn } from "@tauri-apps/plugin-log";
 import {
@@ -922,6 +923,10 @@ export async function runWorkflow(opts: RunOptions): Promise<PulseOutcome> {
         actor_member_id: actor?.id ?? null,
         timestamp_at: item.timestamp_at,
         content: item.content,
+        // v0.2.7+: compute the ctxd subject path so PR 10 can render
+        // citation chips that pivot to the canonical event. NULL is
+        // fine when the source has no defined mapping yet.
+        subject_path: evidenceSubjectFor(item.source, item.source_id, item.source_url),
       }))
     );
 


### PR DESCRIPTION
## Summary

First dual-write of real Keepr events into ctxd. Subjects are now a public contract (frozen by golden tests + ADR-001). Markdown stays canonical; ctxd is a derived index. Fire-and-forget — daemon offline doesn't impact session flow.

## Subject schema (PUBLIC CONTRACT)

| Concept | Subject | ID strategy |
|---|---|---|
| Person | \`/keepr/people/{uuid}\` | UUID, not slug |
| Session | \`/keepr/sessions/{date}/{workflow}/{slug}\` | composite |
| Topic | \`/keepr/topics/{slug}\` | kebab-case |
| Follow-up | \`/keepr/followups/{id}\` | DB integer |
| Status | \`/keepr/status\` | singleton |
| Evidence | \`/keepr/evidence/{source}/...\` | bridge namespace |

See [ADR-001](./docs/decisions/001-ctxd-subject-schema.md) for the rationale, especially why UUIDs for people.

## What ships

- \`src/services/ctxSubjects.ts\` — path builders + 13 EVENT_TYPES + SCHEMA_VERSION=1
- \`docs/decisions/001-ctxd-subject-schema.md\` — the ADR
- \`db.ts ensureCtxdUuid()\` — lazy UUID population (migration #10 finally has a writer)
- \`pipeline.ts\` populates \`evidence_items.subject_path\` via \`evidenceSubjectFor()\`
- \`memory.ts dualWriteSession()\` — fire-and-forget after markdown write, gated by \`app_config.memory_dual_write\` (default true)

## Failure semantics

- Daemon offline → memoryWrite throws → Promise.allSettled collects → one logWarn with count → markdown returned long ago, session fine.
- ensureCtxdUuid DB error → warn + skip that person, continue others.
- memory_dual_write=false → no work done, returns immediately.

## Tests

| Suite | Before | After |
|---|---|---|
| vitest | 253 | **288** (+24 ctxSubjects, +11 dualWrite) |
| cargo test | 20 | 20 |
| tsc | clean | clean |

## Test plan

- [x] \`npm run test:run\` — 288 pass
- [x] \`cargo test --lib\` — 20 pass
- [x] \`npx tsc --noEmit\` — clean
- [ ] Manual smoke: trigger a session in dev, observe markdown writes complete, ctxd events appear under \`/keepr/sessions/...\` (deferred to integration smoke test once we have a session run with real data)

## Related

- ADR-001: subject schema
- Plan: \`tasks/ctxd-integration.md\`
- Architecture: \`docs/architecture/ctxd-topology.md\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)