### PR TITLE
feat(ctxd): RelatedPanel scaffolding — PR 8 of v0.2.7

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,26 @@ store (no migration in v0.2.7) — see `tasks/ctxd-integration.md`.
 > NOTE: `v0.2.6` on `main` was the auto-updater release (Tauri v2 updater
 > plugin). This is a separate, independent milestone. Both ship.
 
+### PR 8 — `feat/related-panel`
+
+- New `src/components/RelatedPanel.tsx` — right-edge panel that opens
+  when a memory subject is selected (currently from MemorySearch row
+  clicks; PR 10 will also wire it to pulse-citation chips).
+- Calls `memory_related(subject)`. Groups results by `data.relation`
+  field (when ctxd-adapter writes one) or by `event_type` as fallback.
+- Empty / not_yet_supported / offline / internal-error states each
+  render distinct messaging — never a toast, never a crash.
+- Wired in App.tsx as a single `relatedSubject` state; MemorySearch's
+  `onOpenSubject` opens the panel; the panel's row click drills into
+  another subject without closing.
+- 11 new vitest tests (319 total): covers null-subject (renders
+  nothing), empty array, not_yet_supported, offline, internal,
+  grouping by relation field, fallback grouping by event_type, click
+  drilldown, close button, re-fetch on subject change.
+- Note: `memory_related` returns `NotYetSupported` against the v0.3.0
+  ctxd SDK. The panel renders "Coming soon" until v0.4 SDK lands —
+  scaffolding ships now so the upgrade is a single dep bump.
+
 ### PR 6 — `feat/memory-search`
 
 - New screen `src/screens/MemorySearch.tsx` — full-results view backed

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import { open as openExternal } from "@tauri-apps/plugin-shell";
 import { Titlebar } from "./components/Titlebar";
 import { Sidebar, type ViewKey } from "./components/Sidebar";
 import { CommandPalette, type CommandAction } from "./components/CommandPalette";
+import { RelatedPanel } from "./components/RelatedPanel";
 import { SessionReader } from "./components/SessionReader";
 import { PersonDetail } from "./components/PersonDetail";
 import { RunOverlay, type RunState } from "./components/RunOverlay";
@@ -61,6 +62,10 @@ export default function App() {
   const [integrations, setIntegrations] = useState<Integration[]>([]);
   const [topics, setTopics] = useState<string[]>([]);
   const [paletteOpen, setPaletteOpen] = useState(false);
+  // v0.2.7+: subject currently shown in the right-hand RelatedPanel.
+  // Null = panel hidden. Opened from MemorySearch row clicks (and, in
+  // PR 10, from pulse-citation chips).
+  const [relatedSubject, setRelatedSubject] = useState<string | null>(null);
   const [sidebarOpen, setSidebarOpen] = useState(true);
   const [runState, setRunState] = useState<RunState | null>(null);
   const runControllerRef = useRef<AbortController | null>(null);
@@ -684,9 +689,7 @@ export default function App() {
               members={members}
               initialQuery={view.q}
               initialSubject={view.subject}
-              onOpenSubject={(s) =>
-                setView({ kind: "memory_search", subject: s })
-              }
+              onOpenSubject={(s) => setRelatedSubject(s)}
             />
           )}
           </div>
@@ -710,6 +713,11 @@ export default function App() {
         onCancel={cancelRun}
         onTryLongerWindow={handleTryLongerWindow}
         onFixInSettings={handleFixInSettings}
+      />
+      <RelatedPanel
+        subject={relatedSubject}
+        onClose={() => setRelatedSubject(null)}
+        onOpenSubject={(s) => setRelatedSubject(s)}
       />
       {demoMode && <DemoPill onExit={handleExitDemo} />}
     </div>

--- a/src/components/RelatedPanel.tsx
+++ b/src/components/RelatedPanel.tsx
@@ -1,0 +1,222 @@
+// RelatedPanel — entity neighborhood for a ctxd subject.
+//
+// v0.2.7 PR 8: scaffolding + UI shape. The underlying `memory_related`
+// command currently returns `NotYetSupported` because the v0.3.0 SDK
+// doesn't expose `ctx_related`; the panel renders an empty state until
+// the v0.4 SDK lands. When that bumps, this component starts surfacing
+// real results without contract changes.
+//
+// Open path: triggered from MemorySearch row clicks, evidence cards
+// (PR 10's pulse citations), and the cmd+k palette in v0.3.0.
+
+import { useEffect, useState } from "react";
+import {
+  isEmptyResult,
+  isTransientError,
+  memoryRelated,
+  type EventRow,
+} from "../services/ctxStore";
+
+interface Props {
+  subject: string | null;
+  onClose: () => void;
+  onOpenSubject?: (subject: string) => void;
+}
+
+type Status =
+  | { kind: "idle" }
+  | { kind: "loading" }
+  | { kind: "ready"; results: EventRow[] }
+  | { kind: "empty" }
+  | { kind: "offline" }
+  | { kind: "error"; message: string }
+  /** v0.2.7: SDK doesn't expose related yet; surface a quiet "coming soon"
+   *  empty state instead of an error. */
+  | { kind: "unsupported" };
+
+export function RelatedPanel({ subject, onClose, onOpenSubject }: Props) {
+  const [status, setStatus] = useState<Status>({ kind: "idle" });
+
+  useEffect(() => {
+    if (!subject) {
+      setStatus({ kind: "idle" });
+      return;
+    }
+    let cancelled = false;
+    setStatus({ kind: "loading" });
+    (async () => {
+      try {
+        const results = await memoryRelated(subject);
+        if (cancelled) return;
+        if (results.length === 0) setStatus({ kind: "empty" });
+        else setStatus({ kind: "ready", results });
+      } catch (err) {
+        if (cancelled) return;
+        if (isEmptyResult(err)) {
+          // not_yet_supported is the v0.2.7 reality — show "coming soon"
+          // rather than empty so users know the feature exists in the
+          // roadmap, not that it failed to find anything.
+          if ((err as { kind?: string })?.kind === "not_yet_supported") {
+            setStatus({ kind: "unsupported" });
+          } else {
+            setStatus({ kind: "empty" });
+          }
+        } else if (isTransientError(err)) {
+          setStatus({ kind: "offline" });
+        } else {
+          setStatus({
+            kind: "error",
+            message:
+              err instanceof Error
+                ? err.message
+                : (err as { message?: string })?.message || "Unknown error",
+          });
+        }
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [subject]);
+
+  if (!subject) return null;
+
+  const grouped = status.kind === "ready" ? groupByRelation(status.results) : null;
+
+  return (
+    <aside
+      className="fixed top-0 right-0 z-40 h-full w-[min(380px,90vw)] bg-canvas border-l border-hairline shadow-[-2px_0_8px_rgba(0,0,0,0.04)] flex flex-col"
+      aria-label="Related memory panel"
+    >
+      <div className="flex items-center justify-between px-5 py-4 border-b border-hairline">
+        <div className="min-w-0 flex-1">
+          <div className="text-[9.5px] font-semibold uppercase tracking-[0.16em] text-ink-faint">
+            Related memory
+          </div>
+          <div className="mt-1 truncate text-xs text-ink-soft">{subject}</div>
+        </div>
+        <button
+          onClick={onClose}
+          aria-label="Close related panel"
+          className="ml-4 text-ink-faint hover:text-ink text-base"
+        >
+          ×
+        </button>
+      </div>
+
+      <div className="flex-1 overflow-y-auto px-2 py-2">
+        {status.kind === "loading" && (
+          <div className="px-4 py-6 text-xs text-ink-faint">Loading…</div>
+        )}
+        {status.kind === "empty" && (
+          <EmptyState
+            title="No related memory yet"
+            note="Nothing else in the memory layer references this subject."
+          />
+        )}
+        {status.kind === "unsupported" && (
+          <EmptyState
+            title="Coming soon"
+            note="Cross-source links arrive in v0.4 when the ctxd SDK exposes ctx_related."
+          />
+        )}
+        {status.kind === "offline" && (
+          <EmptyState
+            title="Memory layer offline"
+            note="The local memory daemon isn't responding. Try again in a moment."
+          />
+        )}
+        {status.kind === "error" && (
+          <EmptyState
+            title="Something went wrong"
+            note={status.message}
+          />
+        )}
+        {status.kind === "ready" && grouped && (
+          <div className="space-y-4 px-2 py-2">
+            {grouped.map(([relation, events]) => (
+              <section key={relation}>
+                <div className="mb-1 px-1 text-[9.5px] font-semibold uppercase tracking-[0.16em] text-ink-faint">
+                  {relation}
+                </div>
+                <div className="divide-y divide-hairline">
+                  {events.map((ev) => (
+                    <button
+                      key={ev.id}
+                      onClick={() => onOpenSubject?.(ev.subject)}
+                      className="flex w-full items-start gap-2 py-2 text-left hover:bg-[rgba(10,10,10,0.025)] rounded-sm transition-colors duration-180"
+                    >
+                      <span className="mt-[3px] shrink-0 w-12 text-[10px] uppercase tracking-[0.12em] text-ink-faint">
+                        {kindLabel(ev.subject)}
+                      </span>
+                      <div className="min-w-0 flex-1">
+                        <div className="truncate text-xs text-ink">
+                          {bestTitle(ev)}
+                        </div>
+                        <div className="truncate text-[10px] text-ink-faint">
+                          {ev.subject}
+                        </div>
+                      </div>
+                    </button>
+                  ))}
+                </div>
+              </section>
+            ))}
+          </div>
+        )}
+      </div>
+    </aside>
+  );
+}
+
+// ---------- helpers --------------------------------------------------
+
+function groupByRelation(events: EventRow[]): Array<[string, EventRow[]]> {
+  // The v0.4 SDK shape is unknown. For now group by event_type — ctxd's
+  // `ctx_related` is expected to return events with their original types
+  // and a `relation` field on the data payload. We honor `data.relation`
+  // when present; else fall back to event_type.
+  const groups = new Map<string, EventRow[]>();
+  for (const ev of events) {
+    const relationFromData =
+      typeof (ev.data as Record<string, unknown> | null)?.relation === "string"
+        ? ((ev.data as { relation: string }).relation as string)
+        : null;
+    const key = relationFromData || ev.event_type || "related";
+    const arr = groups.get(key) || [];
+    arr.push(ev);
+    groups.set(key, arr);
+  }
+  return Array.from(groups.entries());
+}
+
+function kindLabel(subject: string): string {
+  const parts = subject.split("/").filter(Boolean);
+  if (parts[0] === "keepr") {
+    if (parts[1] === "people") return "person";
+    if (parts[1] === "sessions") return "session";
+    if (parts[1] === "topics") return "topic";
+    if (parts[1] === "followups") return "f-up";
+    if (parts[1] === "status") return "status";
+    if (parts[1] === "evidence") return parts[2] || "ev";
+  }
+  if (parts[0] === "work") return parts[1] || "work";
+  return parts[0] || "ev";
+}
+
+function bestTitle(ev: EventRow): string {
+  const data = ev.data as Record<string, unknown> | null | undefined;
+  return String(
+    (data && (data.summary || data.line || data.name || data.display_name)) ??
+      ev.event_type
+  );
+}
+
+function EmptyState({ title, note }: { title: string; note: string }) {
+  return (
+    <div className="px-4 py-10 text-center">
+      <div className="display-serif text-[15px] text-ink-muted">{title}</div>
+      <div className="mt-1 text-[11px] text-ink-faint">{note}</div>
+    </div>
+  );
+}

--- a/src/components/__tests__/RelatedPanel.test.tsx
+++ b/src/components/__tests__/RelatedPanel.test.tsx
@@ -1,0 +1,163 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const memoryRelatedMock = vi.fn();
+vi.mock("../../services/ctxStore", () => ({
+  memoryRelated: (...a: unknown[]) => memoryRelatedMock(...a),
+  isEmptyResult: (err: unknown) => {
+    if (typeof err !== "object" || err === null) return false;
+    const e = err as { kind?: string };
+    return e.kind === "not_found" || e.kind === "not_yet_supported";
+  },
+  isTransientError: (err: unknown) => {
+    if (typeof err !== "object" || err === null) return false;
+    const e = err as { kind?: string };
+    return e.kind === "offline" || e.kind === "timeout";
+  },
+}));
+
+import { RelatedPanel } from "../RelatedPanel";
+
+beforeEach(() => {
+  memoryRelatedMock.mockReset();
+});
+
+describe("RelatedPanel", () => {
+  it("renders nothing when subject is null", () => {
+    const { container } = render(<RelatedPanel subject={null} onClose={() => {}} />);
+    expect(container.firstChild).toBeNull();
+    expect(memoryRelatedMock).not.toHaveBeenCalled();
+  });
+
+  it("calls memory_related on mount with the given subject", async () => {
+    memoryRelatedMock.mockResolvedValue([]);
+    render(<RelatedPanel subject="/keepr/people/uuid-1" onClose={() => {}} />);
+    await waitFor(() =>
+      expect(memoryRelatedMock).toHaveBeenCalledWith("/keepr/people/uuid-1")
+    );
+  });
+
+  it("renders the empty state when memory_related returns []", async () => {
+    memoryRelatedMock.mockResolvedValue([]);
+    render(<RelatedPanel subject="/keepr/topics/x" onClose={() => {}} />);
+    await waitFor(() =>
+      expect(screen.getByText("No related memory yet")).toBeDefined()
+    );
+  });
+
+  it("renders the 'Coming soon' state for not_yet_supported (v0.2.7 SDK gap)", async () => {
+    memoryRelatedMock.mockRejectedValue({
+      kind: "not_yet_supported",
+      message: "ctxd-client v0.3.0 lacks ctx_related",
+    });
+    render(<RelatedPanel subject="/keepr/topics/x" onClose={() => {}} />);
+    await waitFor(() => expect(screen.getByText("Coming soon")).toBeDefined());
+    expect(screen.getByText(/v0.4/i)).toBeDefined();
+  });
+
+  it("renders 'Memory layer offline' for transient errors", async () => {
+    memoryRelatedMock.mockRejectedValue({
+      kind: "offline",
+      message: "memory layer offline",
+    });
+    render(<RelatedPanel subject="/keepr/topics/x" onClose={() => {}} />);
+    await waitFor(() =>
+      expect(screen.getByText("Memory layer offline")).toBeDefined()
+    );
+  });
+
+  it("renders 'Something went wrong' for unrecognized errors", async () => {
+    memoryRelatedMock.mockRejectedValue({
+      kind: "internal",
+      message: "boom",
+    });
+    render(<RelatedPanel subject="/keepr/topics/x" onClose={() => {}} />);
+    await waitFor(() =>
+      expect(screen.getByText("Something went wrong")).toBeDefined()
+    );
+    expect(screen.getByText("boom")).toBeDefined();
+  });
+
+  it("renders related events grouped by relation field on data payload", async () => {
+    memoryRelatedMock.mockResolvedValue([
+      {
+        id: "a",
+        subject: "/keepr/people/uuid-1",
+        event_type: "person.fact",
+        data: { line: "Authored", relation: "actor" },
+        timestamp: "2026-04-29T00:00:00+00:00",
+      },
+      {
+        id: "b",
+        subject: "/keepr/topics/auth-rewrite",
+        event_type: "topic.note",
+        data: { name: "Linked topic", relation: "mentions" },
+        timestamp: "2026-04-29T00:00:00+00:00",
+      },
+    ]);
+    render(<RelatedPanel subject="/keepr/sessions/x" onClose={() => {}} />);
+    await waitFor(() => {
+      expect(screen.getByText("actor")).toBeDefined();
+      expect(screen.getByText("mentions")).toBeDefined();
+    });
+    expect(screen.getByText("Authored")).toBeDefined();
+    expect(screen.getByText("Linked topic")).toBeDefined();
+  });
+
+  it("falls back to event_type for grouping when relation field is absent", async () => {
+    memoryRelatedMock.mockResolvedValue([
+      {
+        id: "a",
+        subject: "/keepr/people/uuid-1",
+        event_type: "person.fact",
+        data: { line: "x" },
+        timestamp: "2026-04-29T00:00:00+00:00",
+      },
+    ]);
+    render(<RelatedPanel subject="/keepr/sessions/x" onClose={() => {}} />);
+    await waitFor(() => expect(screen.getByText("person.fact")).toBeDefined());
+  });
+
+  it("clicking a row fires onOpenSubject", async () => {
+    memoryRelatedMock.mockResolvedValue([
+      {
+        id: "a",
+        subject: "/keepr/topics/auth-rewrite",
+        event_type: "topic.note",
+        data: { name: "Auth Rewrite" },
+        timestamp: "2026-04-29T00:00:00+00:00",
+      },
+    ]);
+    const onOpenSubject = vi.fn();
+    render(
+      <RelatedPanel
+        subject="/keepr/sessions/x"
+        onClose={() => {}}
+        onOpenSubject={onOpenSubject}
+      />
+    );
+    await waitFor(() => expect(screen.getByText("Auth Rewrite")).toBeDefined());
+    fireEvent.click(screen.getByText("Auth Rewrite"));
+    expect(onOpenSubject).toHaveBeenCalledWith("/keepr/topics/auth-rewrite");
+  });
+
+  it("close button fires onClose", async () => {
+    memoryRelatedMock.mockResolvedValue([]);
+    const onClose = vi.fn();
+    render(<RelatedPanel subject="/keepr/topics/x" onClose={onClose} />);
+    await waitFor(() => expect(screen.getByLabelText(/close related/i)).toBeDefined());
+    fireEvent.click(screen.getByLabelText(/close related/i));
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("re-fetches when subject changes", async () => {
+    memoryRelatedMock.mockResolvedValue([]);
+    const { rerender } = render(
+      <RelatedPanel subject="/keepr/topics/a" onClose={() => {}} />
+    );
+    await waitFor(() => expect(memoryRelatedMock).toHaveBeenCalledTimes(1));
+    rerender(<RelatedPanel subject="/keepr/topics/b" onClose={() => {}} />);
+    await waitFor(() => expect(memoryRelatedMock).toHaveBeenCalledTimes(2));
+    expect(memoryRelatedMock).toHaveBeenLastCalledWith("/keepr/topics/b");
+  });
+});


### PR DESCRIPTION
Right-edge panel showing entity neighborhood for a subject. Opens from MemorySearch row clicks. memory_related returns NotYetSupported in v0.3.0 SDK; panel shows 'Coming soon'. 11 new tests, 318 total.