### PR TITLE
feat(ctxd): pulse citation chips → RelatedPanel — PR 10 of v0.2.7

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,23 @@ store (no migration in v0.2.7) — see `tasks/ctxd-integration.md`.
 > NOTE: `v0.2.6` on `main` was the auto-updater release (Tauri v2 updater
 > plugin). This is a separate, independent milestone. Both ship.
 
+### PR 10 — `feat/pulse-citations`
+
+- `SessionReader` evidence cards gain a `related ⇢` chip next to the
+  existing `open ↗` chip when the row has a `subject_path` (populated
+  by PR 3's dual-write pipeline). Clicking opens the RelatedPanel from
+  PR 8 with that evidence's ctxd subject.
+- New `onOpenRelated` prop on `SessionReader`; App.tsx wires it to
+  `setRelatedSubject`. Same panel-open path as MemorySearch row clicks.
+- Pure rendering change — no prompt edits, no LLM behavior change.
+  Older evidence rows (subject_path NULL) get no chip; v0.4 backfill
+  will populate them.
+- Behavior is covered transitively:
+  - `evidenceSubjectFor` mapping → ctxSubjects tests (24).
+  - `RelatedPanel` open/empty/error states → RelatedPanel tests (11).
+  - The chip itself is a 4-line conditional render; no dedicated test
+    to avoid a heavy SessionReader mock-graph rebuild.
+
 ### PR 8 — `feat/related-panel`
 
 - New `src/components/RelatedPanel.tsx` — right-edge panel that opens

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -656,6 +656,7 @@ export default function App() {
               members={members}
               onRetry={rerunSession}
               onDelete={deleteSessionAndRefresh}
+              onOpenRelated={(subject) => setRelatedSubject(subject)}
             />
           )}
           {view.kind === "memory" && (

--- a/src/components/SessionReader.tsx
+++ b/src/components/SessionReader.tsx
@@ -53,6 +53,11 @@ interface Props {
   members: TeamMember[];
   onRetry?: (session: SessionRow) => void;
   onDelete?: (id: number) => void;
+  /** v0.2.7+: open the right-edge RelatedPanel for this evidence's
+   *  ctxd subject. App.tsx wires it to `setRelatedSubject`. Only
+   *  surfaces on evidence rows that have a `subject_path` (forward-only,
+   *  populated since v0.2.7 PR 3). */
+  onOpenRelated?: (subjectPath: string) => void;
 }
 
 export function SessionReader({
@@ -62,6 +67,7 @@ export function SessionReader({
   members,
   onRetry,
   onDelete,
+  onOpenRelated,
 }: Props) {
   const targetMember = useMemo(
     () =>
@@ -437,6 +443,22 @@ ${rendered}
                       >
                         open ↗
                       </button>
+                      {ev.subject_path && onOpenRelated && (
+                        <>
+                          <span className="text-ink-ghost">·</span>
+                          <button
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              onOpenRelated(ev.subject_path!);
+                            }}
+                            className="text-ink-muted transition-colors duration-180 hover:text-ink"
+                            aria-label="Show related memory"
+                            title="Show related memory"
+                          >
+                            related ⇢
+                          </button>
+                        </>
+                      )}
                     </div>
                   </div>
                 </div>


### PR DESCRIPTION
Evidence cards gain a 'related ⇢' chip when subject_path is populated; click opens RelatedPanel. Pure rendering, no prompt change. 318 vitest still pass.