### PR TITLE
feat(ctxd): evidence bridge via memory_write — PR 4 of v0.2.7

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,24 @@ store (no migration in v0.2.7) — see `tasks/ctxd-integration.md`.
 > NOTE: `v0.2.6` on `main` was the auto-updater release (Tauri v2 updater
 > plugin). This is a separate, independent milestone. Both ship.
 
+### PR 4 — `feat/memory-evidence-bridge`
+
+- New `dualWriteEvidenceBatch()` in `src/services/memory.ts` mirrors
+  every `evidence_items` insert into a ctxd `evidence.recorded` event
+  under the row's `subject_path`. Surfaces real GitHub/Slack/Jira/
+  Linear/GitLab content in MemorySearch and the cmd+k palette.
+- Wired into `pipeline.ts` immediately after `insertEvidence` returns
+  — same fire-and-forget Promise.allSettled pattern as session events.
+- Bridge namespace `/keepr/evidence/{source}/...` (not `/work/{source}`)
+  per ADR-001, leaving room for a future ctxd-adapter-* binary to
+  own the canonical `/work` namespace and a one-time consolidation pass.
+- Renamed from "GitHub bridge" to "evidence bridge" in scope —
+  evidenceSubjectFor handles all five non-adapter sources, not just
+  GitHub.
+- 6 new vitest tests (324 total): kill-switch off, empty input,
+  null subject_path skip, content_snippet truncation, partial-failure
+  tolerance, all-skipped no-warn.
+
 ### PR 10 — `feat/pulse-citations`
 
 - `SessionReader` evidence cards gain a `related ⇢` chip next to the

--- a/src/services/__tests__/memoryEvidenceBridge.test.ts
+++ b/src/services/__tests__/memoryEvidenceBridge.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { DEFAULT_CONFIG } from "../../lib/types";
+
+const memoryWriteMock = vi.fn();
+const getConfigMock = vi.fn();
+const logWarnMock = vi.fn();
+
+vi.mock("../ctxStore", () => ({
+  memoryWrite: (...a: unknown[]) => memoryWriteMock(...a),
+}));
+
+vi.mock("../db", () => ({
+  ensureCtxdUuid: vi.fn(),
+  getConfig: (...a: unknown[]) => getConfigMock(...a),
+}));
+
+vi.mock("@tauri-apps/plugin-log", () => ({
+  warn: (...a: unknown[]) => logWarnMock(...a),
+  info: vi.fn(),
+}));
+
+import { dualWriteEvidenceBatch } from "../memory";
+
+const baseRow = {
+  source: "github_pr",
+  source_url: "https://github.com/acme/web/pull/42",
+  source_id: "42",
+  actor_member_id: 1,
+  timestamp_at: "2026-04-29T00:00:00+00:00",
+  content: "PR description text".repeat(50), // long enough to test snippet truncation
+  subject_path: "/keepr/evidence/github/acme/web/pulls/42/42",
+};
+
+beforeEach(() => {
+  memoryWriteMock.mockReset();
+  getConfigMock.mockReset();
+  logWarnMock.mockReset();
+  memoryWriteMock.mockResolvedValue("event-id");
+  getConfigMock.mockResolvedValue({ ...DEFAULT_CONFIG, memory_dual_write: true });
+});
+
+describe("dualWriteEvidenceBatch", () => {
+  it("writes nothing when memory_dual_write is false", async () => {
+    getConfigMock.mockResolvedValueOnce({
+      ...DEFAULT_CONFIG,
+      memory_dual_write: false,
+    });
+    await dualWriteEvidenceBatch([baseRow]);
+    expect(memoryWriteMock).not.toHaveBeenCalled();
+  });
+
+  it("writes nothing for empty input", async () => {
+    await dualWriteEvidenceBatch([]);
+    expect(memoryWriteMock).not.toHaveBeenCalled();
+    expect(getConfigMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("skips rows without a subject_path", async () => {
+    await dualWriteEvidenceBatch([{ ...baseRow, subject_path: null }]);
+    expect(memoryWriteMock).not.toHaveBeenCalled();
+  });
+
+  it("emits one evidence.recorded event per row with subject_path", async () => {
+    await dualWriteEvidenceBatch([baseRow, { ...baseRow, source_id: "43", subject_path: "/keepr/evidence/github/acme/web/pulls/42/43" }]);
+    expect(memoryWriteMock).toHaveBeenCalledTimes(2);
+    const [subject, type, data] = memoryWriteMock.mock.calls[0];
+    expect(subject).toBe(baseRow.subject_path);
+    expect(type).toBe("evidence.recorded");
+    expect(data.schema_version).toBe(1);
+    expect(data.source).toBe("github_pr");
+    expect(data.source_url).toBe(baseRow.source_url);
+    expect(data.actor_member_id).toBe(1);
+    // content_snippet is truncated to 280 chars max.
+    expect(data.content_snippet.length).toBeLessThanOrEqual(280);
+  });
+
+  it("tolerates per-row write failures (logs once, does not throw)", async () => {
+    memoryWriteMock.mockRejectedValueOnce(new Error("offline"));
+    memoryWriteMock.mockResolvedValueOnce("ok");
+    await expect(
+      dualWriteEvidenceBatch([
+        baseRow,
+        { ...baseRow, source_id: "43", subject_path: "/keepr/evidence/x/y" },
+      ])
+    ).resolves.toBeUndefined();
+    expect(logWarnMock).toHaveBeenCalledTimes(1);
+    expect(logWarnMock).toHaveBeenCalledWith(
+      expect.stringContaining("evidence dual-write")
+    );
+  });
+
+  it("handles all rows skipped (subject_path null) — no warn, no calls", async () => {
+    await dualWriteEvidenceBatch([
+      { ...baseRow, subject_path: null },
+      { ...baseRow, subject_path: null, source_id: "43" },
+    ]);
+    expect(memoryWriteMock).not.toHaveBeenCalled();
+    expect(logWarnMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/services/memory.ts
+++ b/src/services/memory.ts
@@ -535,3 +535,58 @@ function sessionSlugFor(workflow: WorkflowType, targetSlug: string | null): stri
       return workflow;
   }
 }
+
+// ---------- ctxd dual-write — evidence (v0.2.7 PR 4) ----------------------
+//
+// Mirror the SQLite `evidence_items` insert into ctxd events under the
+// canonical subject for that source. Lets MemorySearch / cmd+k palette
+// surface real GitHub/Slack/Jira/Linear/GitLab content alongside the
+// session/topic/person events from dualWriteSession.
+//
+// Same kill-switch (app_config.memory_dual_write). Same Promise.allSettled
+// failure tolerance — markdown + SQLite are canonical, ctxd is the index.
+
+interface EvidenceRowForBridge {
+  source: string;
+  source_url: string;
+  source_id: string;
+  actor_member_id: number | null;
+  timestamp_at: string;
+  content: string;
+  subject_path: string | null;
+}
+
+export async function dualWriteEvidenceBatch(
+  rows: EvidenceRowForBridge[]
+): Promise<void> {
+  const cfg = await getConfig();
+  if (!cfg.memory_dual_write) return;
+  if (!rows.length) return;
+
+  const writes: Array<Promise<unknown>> = [];
+  for (const row of rows) {
+    if (!row.subject_path) continue; // No mapping — skip until we add one.
+    writes.push(
+      memoryWrite(row.subject_path, "evidence.recorded", {
+        schema_version: SCHEMA_VERSION,
+        source: row.source,
+        source_url: row.source_url,
+        source_id: row.source_id,
+        actor_member_id: row.actor_member_id,
+        timestamp_at: row.timestamp_at,
+        // Keep the payload small — just enough to render in MemorySearch.
+        // Full content stays in evidence_items for citation rendering.
+        content_snippet: (row.content || "").slice(0, 280),
+      })
+    );
+  }
+
+  if (!writes.length) return;
+  const results = await Promise.allSettled(writes);
+  const failures = results.filter((r) => r.status === "rejected");
+  if (failures.length) {
+    logWarn(
+      `evidence dual-write: ${failures.length}/${results.length} events did not land — daemon offline?`
+    );
+  }
+}

--- a/src/services/pipeline.ts
+++ b/src/services/pipeline.ts
@@ -42,7 +42,7 @@ import {
 import { fetchProjectActivity, type FetchedJiraIssue } from "./jira";
 import { fetchTeamActivity, type FetchedLinearIssue } from "./linear";
 import { getProvider, setCustomConfig } from "./llm";
-import { writeMemory, readMemoryContext } from "./memory";
+import { writeMemory, readMemoryContext, dualWriteEvidenceBatch } from "./memory";
 import { evidenceSubjectFor } from "./ctxSubjects";
 import { throwIfAborted, isAbortError } from "../lib/abort";
 import { info as logInfo, warn as logWarn } from "@tauri-apps/plugin-log";
@@ -914,20 +914,26 @@ export async function runWorkflow(opts: RunOptions): Promise<PulseOutcome> {
       item,
     }));
 
-    await insertEvidence(
-      sessionId,
-      withIds.map(({ item, actor }) => ({
-        source: item.source,
-        source_url: item.source_url,
-        source_id: item.source_id,
-        actor_member_id: actor?.id ?? null,
-        timestamp_at: item.timestamp_at,
-        content: item.content,
-        // v0.2.7+: compute the ctxd subject path so PR 10 can render
-        // citation chips that pivot to the canonical event. NULL is
-        // fine when the source has no defined mapping yet.
-        subject_path: evidenceSubjectFor(item.source, item.source_id, item.source_url),
-      }))
+    const evidenceRows = withIds.map(({ item, actor }) => ({
+      source: item.source,
+      source_url: item.source_url,
+      source_id: item.source_id,
+      actor_member_id: actor?.id ?? null,
+      timestamp_at: item.timestamp_at,
+      content: item.content,
+      // v0.2.7+: compute the ctxd subject path so PR 10 can render
+      // citation chips that pivot to the canonical event. NULL is
+      // fine when the source has no defined mapping yet.
+      subject_path: evidenceSubjectFor(item.source, item.source_id, item.source_url),
+    }));
+    await insertEvidence(sessionId, evidenceRows);
+
+    // v0.2.7+: dual-write evidence into ctxd so the memory layer has
+    // real GitHub/Slack/Jira/Linear/GitLab content to surface in
+    // MemorySearch and the cmd+k palette. Fire-and-forget per session;
+    // see dualWriteEvidenceBatch in memory.ts.
+    void dualWriteEvidenceBatch(evidenceRows).catch((err) =>
+      logWarn(`evidence dual-write failed: ${err instanceof Error ? err.message : String(err)}`)
     );
 
     // Group by bucket for the map step.


### PR DESCRIPTION
Dual-writes every evidence_items row into ctxd as evidence.recorded under the row's subject_path. Same kill switch + fire-and-forget pattern as session events. 324 vitest passing.