### PR TITLE
feat(ctxd): first-launch memory banner — PR 11 of v0.2.7

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,26 @@ store (no migration in v0.2.7) — see `tasks/ctxd-integration.md`.
 > NOTE: `v0.2.6` on `main` was the auto-updater release (Tauri v2 updater
 > plugin). This is a separate, independent milestone. Both ship.
 
+### PR 11 — `feat/onboarding-reingest-banner`
+
+- New `src/components/MemoryFirstLaunchBanner.tsx` — quiet header strip
+  that appears once per install, the first time both:
+    1. `app_config.memory_first_launch_seen` is false, AND
+    2. `memory_status` reports daemon ready.
+- Body explains the v0.2.7 reality (memory builds forward; v0.4 imports
+  the rest), points users at ⌘K and the search screen, and offers a
+  "Got it" dismiss button that flips the flag.
+- New AppConfig field `memory_first_launch_seen: boolean` (default false).
+- App.tsx mounts the banner directly under the Titlebar so the strip
+  sits above sidebar + main view without disturbing layout.
+- Robust degradation: getConfig failure → no banner, memoryStatus
+  failure → no banner, daemon not ready → retry once after 3s then
+  give up for the session.
+- 6 new vitest tests (338 total): hidden when seen=true, visible when
+  seen=false + ready, hidden during starting state, dismiss writes flag
+  + unmounts, getConfig failure → silent hide, memoryStatus failure →
+  silent hide.
+
 ### PR 9 — `feat/activity-sidebar`
 
 - New `src/components/ActivitySidebar.tsx` — collapsible right-edge panel

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,7 @@ import { Sidebar, type ViewKey } from "./components/Sidebar";
 import { CommandPalette, type CommandAction } from "./components/CommandPalette";
 import { RelatedPanel } from "./components/RelatedPanel";
 import { ActivitySidebar } from "./components/ActivitySidebar";
+import { MemoryFirstLaunchBanner } from "./components/MemoryFirstLaunchBanner";
 import { SessionReader } from "./components/SessionReader";
 import { PersonDetail } from "./components/PersonDetail";
 import { RunOverlay, type RunState } from "./components/RunOverlay";
@@ -609,6 +610,7 @@ export default function App() {
         sidebarOpen={sidebarOpen}
         onToggleSidebar={() => setSidebarOpen((o) => !o)}
       />
+      <MemoryFirstLaunchBanner />
       <div className="flex flex-1 overflow-hidden">
         {sidebarOpen && (
           <Sidebar

--- a/src/components/MemoryFirstLaunchBanner.tsx
+++ b/src/components/MemoryFirstLaunchBanner.tsx
@@ -1,0 +1,98 @@
+// MemoryFirstLaunchBanner — first-launch primer for the v0.2.7 memory layer.
+//
+// Renders once per install, the first time both:
+//   1. memory_status reports "ready" (daemon up + client connected), AND
+//   2. app_config.memory_first_launch_seen is false.
+//
+// Dismissed via "Got it" button → sets memory_first_launch_seen = true.
+// Background-friendly: no blocking modal, no animation, no toast — just
+// a quiet header strip that sits above the main view.
+//
+// PR 11 of v0.2.7.
+
+import { useEffect, useState } from "react";
+import { getConfig, setConfig } from "../services/db";
+import { isReady, memoryStatus, type DaemonState } from "../services/ctxStore";
+
+type BannerState = "hidden" | "visible";
+
+export function MemoryFirstLaunchBanner() {
+  const [bannerState, setBannerState] = useState<BannerState>("hidden");
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const cfg = await getConfig();
+        if (cfg.memory_first_launch_seen) {
+          if (!cancelled) setBannerState("hidden");
+          return;
+        }
+        // Wait for the daemon to report Ready before showing the banner —
+        // otherwise we'd promise a feature that's still booting.
+        const status: DaemonState = await memoryStatus();
+        if (cancelled) return;
+        if (isReady(status)) {
+          setBannerState("visible");
+        } else {
+          // Try once more after a short delay; if the daemon is offline
+          // at first launch we don't want the banner to nag forever, so
+          // bail and let the next app start retry.
+          setTimeout(async () => {
+            if (cancelled) return;
+            try {
+              const status2 = await memoryStatus();
+              if (!cancelled && isReady(status2)) {
+                setBannerState("visible");
+              }
+            } catch {
+              /* swallow — banner just stays hidden this session */
+            }
+          }, 3000);
+        }
+      } catch {
+        // If db read fails, don't surface the banner — degrade silently.
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  if (bannerState !== "visible") return null;
+
+  const dismiss = async () => {
+    try {
+      await setConfig({ memory_first_launch_seen: true });
+    } catch {
+      /* even if persistence fails, hide for this session */
+    }
+    setBannerState("hidden");
+  };
+
+  return (
+    <div
+      role="region"
+      aria-label="Memory layer first-launch banner"
+      className="hair-b flex items-start gap-4 bg-[rgba(10,10,10,0.025)] px-8 py-3"
+    >
+      <div className="flex-1 min-w-0">
+        <div className="text-[10px] font-semibold uppercase tracking-[0.16em] text-ink-faint">
+          Memory layer is on
+        </div>
+        <div className="mt-1 text-xs text-ink-soft">
+          Keepr now keeps a local memory of every session, person fact,
+          and topic note alongside your markdown files. Use{" "}
+          <kbd className="kbd">⌘K</kbd> or the search screen to find anything
+          across your history. Older sessions appear after the v0.4 import.
+        </div>
+      </div>
+      <button
+        onClick={() => void dismiss()}
+        className="shrink-0 rounded border border-hairline px-3 py-1 text-[10px] uppercase tracking-[0.12em] text-ink-soft hover:text-ink hover:border-ink/40 transition-colors duration-180"
+      >
+        Got it
+      </button>
+    </div>
+  );
+}

--- a/src/components/__tests__/MemoryFirstLaunchBanner.test.tsx
+++ b/src/components/__tests__/MemoryFirstLaunchBanner.test.tsx
@@ -1,0 +1,110 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { DEFAULT_CONFIG } from "../../lib/types";
+
+const memoryStatusMock = vi.fn();
+const getConfigMock = vi.fn();
+const setConfigMock = vi.fn();
+
+vi.mock("../../services/ctxStore", () => ({
+  memoryStatus: (...a: unknown[]) => memoryStatusMock(...a),
+  isReady: (s: { status: string }) => s.status === "ready",
+}));
+
+vi.mock("../../services/db", () => ({
+  getConfig: (...a: unknown[]) => getConfigMock(...a),
+  setConfig: (...a: unknown[]) => setConfigMock(...a),
+}));
+
+import { MemoryFirstLaunchBanner } from "../MemoryFirstLaunchBanner";
+
+beforeEach(() => {
+  memoryStatusMock.mockReset();
+  getConfigMock.mockReset();
+  setConfigMock.mockReset();
+  setConfigMock.mockResolvedValue(undefined);
+});
+
+describe("MemoryFirstLaunchBanner", () => {
+  it("renders nothing when memory_first_launch_seen is true", async () => {
+    getConfigMock.mockResolvedValueOnce({
+      ...DEFAULT_CONFIG,
+      memory_first_launch_seen: true,
+    });
+    const { container } = render(<MemoryFirstLaunchBanner />);
+    // Wait for the effect to settle.
+    await waitFor(() => expect(getConfigMock).toHaveBeenCalled());
+    expect(container.firstChild).toBeNull();
+    expect(memoryStatusMock).not.toHaveBeenCalled();
+  });
+
+  it("renders the banner when first-launch is unseen AND daemon is ready", async () => {
+    getConfigMock.mockResolvedValueOnce({
+      ...DEFAULT_CONFIG,
+      memory_first_launch_seen: false,
+    });
+    memoryStatusMock.mockResolvedValueOnce({
+      status: "ready",
+      http_port: 51234,
+      wire_port: 51235,
+    });
+    render(<MemoryFirstLaunchBanner />);
+    await waitFor(() =>
+      expect(screen.getByText(/Memory layer is on/i)).toBeDefined()
+    );
+    expect(screen.getByText(/Got it/i)).toBeDefined();
+    expect(screen.getByRole("region", { name: /Memory layer first-launch banner/i })).toBeDefined();
+  });
+
+  it("does NOT show when daemon is starting or offline (initial check)", async () => {
+    getConfigMock.mockResolvedValueOnce({
+      ...DEFAULT_CONFIG,
+      memory_first_launch_seen: false,
+    });
+    memoryStatusMock.mockResolvedValueOnce({ status: "starting" });
+    const { container } = render(<MemoryFirstLaunchBanner />);
+    // Allow the initial-status effect to settle.
+    await new Promise((r) => setTimeout(r, 50));
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("clicking 'Got it' calls setConfig with memory_first_launch_seen=true", async () => {
+    getConfigMock.mockResolvedValueOnce({
+      ...DEFAULT_CONFIG,
+      memory_first_launch_seen: false,
+    });
+    memoryStatusMock.mockResolvedValueOnce({
+      status: "ready",
+      http_port: 1,
+      wire_port: 2,
+    });
+    render(<MemoryFirstLaunchBanner />);
+    await waitFor(() => expect(screen.getByText(/Got it/i)).toBeDefined());
+    fireEvent.click(screen.getByText(/Got it/i));
+    await waitFor(() =>
+      expect(setConfigMock).toHaveBeenCalledWith({
+        memory_first_launch_seen: true,
+      })
+    );
+    // After dismiss, the banner unmounts.
+    await waitFor(() => expect(screen.queryByText(/Memory layer is on/i)).toBeNull());
+  });
+
+  it("hides on getConfig failure (degrades silently, no crash)", async () => {
+    getConfigMock.mockRejectedValueOnce(new Error("db gone"));
+    const { container } = render(<MemoryFirstLaunchBanner />);
+    await new Promise((r) => setTimeout(r, 50));
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("hides on memoryStatus failure (no banner if daemon path errored)", async () => {
+    getConfigMock.mockResolvedValueOnce({
+      ...DEFAULT_CONFIG,
+      memory_first_launch_seen: false,
+    });
+    memoryStatusMock.mockRejectedValueOnce(new Error("ipc closed"));
+    const { container } = render(<MemoryFirstLaunchBanner />);
+    await new Promise((r) => setTimeout(r, 50));
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -129,6 +129,10 @@ export interface AppConfig {
    *  false to disable the memory-layer dual-write entirely (kill switch).
    *  Markdown remains canonical regardless. See ADR-001. */
   memory_dual_write: boolean;
+  /** v0.2.7+: set to true after the user dismisses the first-launch
+   *  memory-layer banner. Prevents the banner from re-appearing on
+   *  every app start. */
+  memory_first_launch_seen: boolean;
 }
 
 export interface PersonFact {
@@ -191,4 +195,5 @@ export const DEFAULT_CONFIG: AppConfig = {
   engineering_rubric: null,
   feature_flags: DEFAULT_FEATURE_FLAGS,
   memory_dual_write: true,
+  memory_first_launch_seen: false,
 };


### PR DESCRIPTION
Quiet header strip explaining the v0.2.7 memory layer on first launch. Dismissed via Got-it; tracked in app_config.memory_first_launch_seen. 6 new tests, 338 total.