### PR TITLE
chore: merge main (v0.2.6 auto-updater) into v0.2.7 integration

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,22 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # Refuse to ship a release if the Tauri updater pubkey is still the
+      # default development key. Production must replace it (see docs/signing.md
+      # → "Tauri auto-update signing"). Without this guard we'd ship binaries
+      # that auto-update from a key whose private half is in the repo's git
+      # history — anyone could push a poisoned update.
+      - name: Guard — Tauri updater pubkey must not be the dev default
+        run: |
+          DEV_PUBKEY="dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDU1ODVDMTY1RjVGOTBGMEIK"
+          if grep -F "$DEV_PUBKEY" src-tauri/tauri.conf.json >/dev/null; then
+            echo "::error::tauri.conf.json still has the default dev updater pubkey."
+            echo "Generate a production keypair (npx @tauri-apps/cli signer generate),"
+            echo "replace plugins.updater.pubkey, and set TAURI_SIGNING_PRIVATE_KEY*"
+            echo "secrets. See docs/signing.md."
+            exit 1
+          fi
+
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
@@ -70,6 +86,12 @@ jobs:
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
           APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+          # Tauri updater signing (independent of Apple notarization).
+          # tauri-action picks these up automatically when bundle.createUpdaterArtifacts
+          # is true in tauri.conf.json. Generates Keepr.app.tar.gz, .sig, and latest.json
+          # alongside the DMG and uploads them to the GitHub Release.
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         with:
           tagName: ${{ github.ref_name }}
           releaseName: "Keepr ${{ github.ref_name }}"
@@ -91,6 +113,9 @@ jobs:
         uses: tauri-apps/tauri-action@v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Tauri updater signing — required even for unsigned builds.
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         with:
           tagName: ${{ github.ref_name }}
           releaseName: "Keepr ${{ github.ref_name }}"

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,12 @@
 
 Recorded while building v1 so maintainers can audit what I changed and why.
 
+## v0.2.6 — keepr auto updater (2026-04-29)
+
+### keepr auto updater
+
+- Pushes updates to users on older versions
+
 ## v0.2.5 — Codex Provider + Team member smart selection  (2026-04-28)
 
 ### Codex Provider + Team member smart selection

--- a/docs/signing.md
+++ b/docs/signing.md
@@ -112,3 +112,47 @@ If the release is unsigned, add this to the release notes so users aren't stuck:
 ## When to flip to signed
 
 As soon as the Apple Developer enrollment clears and you've added the six secrets, the next `v*` tag pushes a signed build automatically. No workflow changes required.
+
+---
+
+## Tauri auto-update signing (independent of Apple notarization)
+
+Keepr's auto-updater plugin (Tauri v2) verifies every downloaded bundle against a signing public key embedded in the binary. This is a separate trust chain from Apple code signing — it lets the app refuse a malicious bundle that somehow lands at our GitHub Releases URL. Both signatures are independent: the app can be Apple-signed-and-notarized, Tauri-signed, both, or (today) only Tauri-signed. The auto-updater requires Tauri signing regardless of Apple status.
+
+### One-time keypair generation
+
+Run this once on a developer machine you trust. The private key never leaves that machine — it gets uploaded to GitHub Actions as a secret, not committed.
+
+```bash
+mkdir -p ~/.tauri
+npx @tauri-apps/cli signer generate -w ~/.tauri/keepr-updater.key
+# Choose a strong password when prompted. Save it somewhere safe (1Password, etc).
+```
+
+The command prints two things:
+
+1. **Public key** — paste this into `src-tauri/tauri.conf.json` under `plugins.updater.pubkey`, replacing the `REPLACE_ME_WITH_TAURI_SIGNER_PUBLIC_KEY` placeholder.
+2. **Private key path** — `~/.tauri/keepr-updater.key`. Do NOT commit this file.
+
+### GitHub Actions secrets
+
+Set both in the repo's Settings → Secrets and variables → Actions:
+
+- `TAURI_SIGNING_PRIVATE_KEY` — paste the **contents** of `~/.tauri/keepr-updater.key` (not the path)
+- `TAURI_SIGNING_PRIVATE_KEY_PASSWORD` — the password you chose above
+
+`tauri-action` picks both up automatically when `bundle.createUpdaterArtifacts` is `true` in `tauri.conf.json` (already set). The CI build emits `Keepr.app.tar.gz`, `.sig`, and `latest.json` alongside the DMG, all attached to the GitHub Release.
+
+### Key rotation
+
+If the private key is ever compromised:
+
+1. Generate a new keypair (same `signer generate` command).
+2. Update both GitHub secrets.
+3. Update `pubkey` in `tauri.conf.json` and ship a new release.
+
+Existing installs running with the old pubkey will refuse the new bundle — those users have to upgrade once via Homebrew or DMG to pick up the new pubkey, then auto-update resumes. Same one-time-tax dynamic as the original updater bootstrap.
+
+### Why this matters
+
+Without Tauri signing, anyone who can publish to our GitHub Releases (compromised CI, social-engineered maintainer) could push a malicious bundle that every Keepr user auto-installs. With it, the bundle is rejected unless the signature matches a key only we hold. This is the entire reason Tauri requires signed updater bundles by default.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "keepr",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "keepr",
-      "version": "0.2.4",
+      "version": "0.2.5",
       "dependencies": {
         "@tailwindcss/postcss": "^4.2.2",
         "@tauri-apps/api": "^2.1.1",
@@ -15,9 +15,11 @@
         "@tauri-apps/plugin-http": "^2.0.1",
         "@tauri-apps/plugin-log": "^2.8.0",
         "@tauri-apps/plugin-opener": "^2.2.2",
+        "@tauri-apps/plugin-process": "^2.2.0",
         "@tauri-apps/plugin-shell": "^2.0.1",
         "@tauri-apps/plugin-sql": "^2.0.1",
         "@tauri-apps/plugin-store": "^2.1.0",
+        "@tauri-apps/plugin-updater": "^2.6.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0"
       },
@@ -2037,6 +2039,15 @@
         "@tauri-apps/api": "^2.8.0"
       }
     },
+    "node_modules/@tauri-apps/plugin-process": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-process/-/plugin-process-2.3.1.tgz",
+      "integrity": "sha512-nCa4fGVaDL/B9ai03VyPOjfAHRHSBz5v6F/ObsB73r/dA3MHHhZtldaDMIc0V/pnUw9ehzr2iEG+XkSEyC0JJA==",
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@tauri-apps/api": "^2.8.0"
+      }
+    },
     "node_modules/@tauri-apps/plugin-shell": {
       "version": "2.3.5",
       "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-shell/-/plugin-shell-2.3.5.tgz",
@@ -2062,6 +2073,15 @@
       "license": "MIT OR Apache-2.0",
       "dependencies": {
         "@tauri-apps/api": "^2.8.0"
+      }
+    },
+    "node_modules/@tauri-apps/plugin-updater": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-updater/-/plugin-updater-2.10.1.tgz",
+      "integrity": "sha512-NFYMg+tWOZPJdzE/PpFj2qfqwAWwNS3kXrb1tm1gnBJ9mYzZ4WDRrwy8udzWoAnfGCHLuePNLY1WVCNHnh3eRA==",
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@tauri-apps/api": "^2.10.1"
       }
     },
     "node_modules/@testing-library/dom": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "keepr",
   "private": true,
-  "version": "0.2.5",
+  "version": "0.2.6",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/package.json
+++ b/package.json
@@ -22,9 +22,11 @@
     "@tauri-apps/plugin-http": "^2.0.1",
     "@tauri-apps/plugin-log": "^2.8.0",
     "@tauri-apps/plugin-opener": "^2.2.2",
+    "@tauri-apps/plugin-process": "^2.2.0",
     "@tauri-apps/plugin-shell": "^2.0.1",
     "@tauri-apps/plugin-sql": "^2.0.1",
     "@tauri-apps/plugin-store": "^2.1.0",
+    "@tauri-apps/plugin-updater": "^2.6.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -94,6 +94,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
+]
+
+[[package]]
 name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -923,6 +932,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "derive_more"
 version = "0.99.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1299,6 +1319,17 @@ checksum = "38e2275cc4e4fc009b0669731a1e5ab7ebf11f469eaede2bab9309a5b4d6057f"
 dependencies = [
  "memoffset",
  "rustc_version",
+]
+
+[[package]]
+name = "filetime"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "libredox",
 ]
 
 [[package]]
@@ -2400,9 +2431,11 @@ dependencies = [
  "tauri-plugin-http",
  "tauri-plugin-log",
  "tauri-plugin-opener",
+ "tauri-plugin-process",
  "tauri-plugin-shell",
  "tauri-plugin-sql",
  "tauri-plugin-store",
+ "tauri-plugin-updater",
 ]
 
 [[package]]
@@ -2648,6 +2681,12 @@ name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "minisign-verify"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22f9645cb765ea72b8111f36c522475d2daa0d22c957a9826437e97534bc4e9e"
 
 [[package]]
 name = "miniz_oxide"
@@ -2913,6 +2952,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-osa-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f112d1746737b0da274ef79a23aac283376f335f4095a083a267a082f21db0c0"
+dependencies = [
+ "bitflags 2.11.0",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-foundation",
+]
+
+[[package]]
 name = "objc2-quartz-core"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2969,6 +3020,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2992,6 +3049,20 @@ checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "osakit"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "732c71caeaa72c065bb69d7ea08717bd3f4863a4f451402fc9513e29dbd5261b"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+ "objc2-osa-kit",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -3858,15 +3929,20 @@ dependencies = [
  "http-body",
  "http-body-util",
  "hyper",
+ "hyper-rustls",
  "hyper-util",
  "js-sys",
  "log",
  "percent-encoding",
  "pin-project-lite",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
  "serde",
  "serde_json",
  "sync_wrapper",
  "tokio",
+ "tokio-rustls",
  "tokio-util",
  "tower",
  "tower-http",
@@ -4025,6 +4101,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-native-certs"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
 name = "rustls-pki-types"
 version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4033,6 +4121,33 @@ dependencies = [
  "web-time",
  "zeroize",
 ]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
+dependencies = [
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
@@ -4064,6 +4179,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4128,6 +4252,29 @@ name = "seahash"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags 2.11.0",
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "selectors"
@@ -4998,6 +5145,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
+name = "tar"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
+
+[[package]]
 name = "target-lexicon"
 version = "0.12.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5245,6 +5403,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-process"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d55511a7bf6cd70c8767b02c97bf8134fa434daf3926cfc1be0a0f94132d165a"
+dependencies = [
+ "tauri",
+ "tauri-plugin",
+]
+
+[[package]]
 name = "tauri-plugin-shell"
 version = "2.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5300,6 +5468,39 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tracing",
+]
+
+[[package]]
+name = "tauri-plugin-updater"
+version = "2.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "806d9dac662c2e4594ff03c647a552f2c9bd544e7d0f683ec58f872f952ce4af"
+dependencies = [
+ "base64 0.22.1",
+ "dirs 6.0.0",
+ "flate2",
+ "futures-util",
+ "http",
+ "infer",
+ "log",
+ "minisign-verify",
+ "osakit",
+ "percent-encoding",
+ "reqwest 0.13.2",
+ "rustls",
+ "semver",
+ "serde",
+ "serde_json",
+ "tar",
+ "tauri",
+ "tauri-plugin",
+ "tempfile",
+ "thiserror 2.0.18",
+ "time",
+ "tokio",
+ "url",
+ "windows-sys 0.60.2",
+ "zip",
 ]
 
 [[package]]
@@ -6253,6 +6454,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-root-certs"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "webpki-roots"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7024,6 +7234,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix",
+]
+
+[[package]]
 name = "yoke"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7185,6 +7405,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "zip"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa8cd6af31c3b31c6631b8f483848b91589021b28fffe50adada48d4f4d2ed1"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "indexmap 2.14.0",
+ "memchr",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2413,7 +2413,7 @@ dependencies = [
 
 [[package]]
 name = "keepr"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "anyhow",
  "chrono",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "keepr"
-version = "0.2.5"
+version = "0.2.6"
 description = "Keepr — AI Chief of Staff for Engineering Managers"
 authors = ["Keepr"]
 edition = "2021"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -22,6 +22,8 @@ tauri-plugin-http = "2"
 tauri-plugin-opener = "2"
 tauri-plugin-store = "2"
 tauri-plugin-log = "2"
+tauri-plugin-updater = "2"
+tauri-plugin-process = "2"
 log = "0.4"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -63,6 +63,8 @@
     "sql:allow-select",
     "sql:allow-load",
     "store:default",
-    "log:default"
+    "log:default",
+    "updater:default",
+    "process:default"
   ]
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -281,6 +281,8 @@ pub fn run() {
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_fs::init())
         .plugin(tauri_plugin_http::init())
+        .plugin(tauri_plugin_updater::Builder::new().build())
+        .plugin(tauri_plugin_process::init())
         .plugin(tauri_plugin_store::Builder::default().build())
         .plugin(
             tauri_plugin_sql::Builder::default()

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -29,8 +29,21 @@
       "csp": null
     }
   },
+  "plugins": {
+    "updater": {
+      "active": true,
+      "endpoints": [
+        "https://github.com/keeprlabs/keepr/releases/latest/download/latest.json"
+      ],
+      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDU1ODVDMTY1RjVGOTBGMEIKUldRTEQvbjFaY0dGVlN5WWdzakxUcEszVllXR0plb1hJQXM3RmFzUHM4WEVCL3krdVJkSTNyYjIK",
+      "windows": {
+        "installMode": "passive"
+      }
+    }
+  },
   "bundle": {
     "active": true,
+    "createUpdaterArtifacts": true,
     "targets": [
       "dmg",
       "app"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -35,7 +35,7 @@
       "endpoints": [
         "https://github.com/keeprlabs/keepr/releases/latest/download/latest.json"
       ],
-      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDU1ODVDMTY1RjVGOTBGMEIKUldRTEQvbjFaY0dGVlN5WWdzakxUcEszVllXR0plb1hJQXM3RmFzUHM4WEVCL3krdVJkSTNyYjIK",
+      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDE0NjREMkFBN0RBRDJFQjkKUldTNUxxMTlxdEprRktGU0hJbkdtd1o2Njh2RjBWcnc0OEhXYnBVUSsrVStYQjRHZm9lc1Z1enAK",
       "windows": {
         "installMode": "passive"
       }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Keepr",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "identifier": "app.keepr.desktop",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src/components/UpdateBanner.tsx
+++ b/src/components/UpdateBanner.tsx
@@ -1,109 +1,91 @@
-// Update banner — checks GitHub Releases for a newer version on mount.
-// Shows a dismissable bar at the top of the main view if an update exists.
-// Checks at most once per 24 hours (cached in localStorage).
+// Update banner — thin view layer over the updater singleton in
+// services/updater.ts. State and the actual check/download logic live
+// there so the Settings App panel and this banner share one in-flight
+// download and one ready state (no double-fetches).
 
 import { useEffect, useState } from "react";
-import { fetch as tauriFetch } from "@tauri-apps/plugin-http";
+import { relaunch } from "@tauri-apps/plugin-process";
+import {
+  checkForUpdate,
+  getState,
+  subscribe,
+  type UpdaterState,
+} from "../services/updater";
 
-// Injected by Vite from package.json at build time (see vite.config.ts define).
-// Fallback to manual value if the define isn't configured yet.
-const CURRENT_VERSION: string =
-  typeof __KEEPR_VERSION__ !== "undefined" ? __KEEPR_VERSION__ : "0.2.4";
-const CHECK_INTERVAL_MS = 24 * 60 * 60 * 1000; // 24 hours
-const STORAGE_KEY = "keepr_update_check";
-const GITHUB_API = "https://api.github.com/repos/keeprlabs/keepr/releases/latest";
-
-interface CachedCheck {
-  checkedAt: number;
-  latestVersion: string | null;
-}
+const RECHECK_INTERVAL_MS = 6 * 60 * 60 * 1000; // 6 hours
 
 export function UpdateBanner() {
-  const [latestVersion, setLatestVersion] = useState<string | null>(null);
+  const [state, setState] = useState<UpdaterState>(getState());
   const [dismissed, setDismissed] = useState(false);
+  const [restarting, setRestarting] = useState(false);
 
   useEffect(() => {
-    checkForUpdate().then((v) => {
-      if (v && isNewer(v, CURRENT_VERSION)) {
-        setLatestVersion(v);
-      }
-    });
+    const unsubscribe = subscribe(setState);
+
+    // Kick off the first check on mount. Re-check every 6 hours after
+    // that — so a user who keeps the app open for days still picks up
+    // newer releases without restarting first. The singleton short-
+    // circuits when it's already in `ready` state.
+    checkForUpdate();
+    const id = window.setInterval(() => {
+      checkForUpdate();
+    }, RECHECK_INTERVAL_MS);
+
+    return () => {
+      unsubscribe();
+      window.clearInterval(id);
+    };
   }, []);
 
-  if (!latestVersion || dismissed) return null;
+  // Only render when we have something the user should act on.
+  if (dismissed) return null;
+  if (state.kind !== "ready" && state.kind !== "fallback") return null;
+
+  const handleRestart = async () => {
+    if (state.kind !== "ready") return;
+    setRestarting(true);
+    try {
+      await relaunch();
+    } catch (err) {
+      console.error("Failed to relaunch after update install:", err);
+      setRestarting(false);
+    }
+  };
 
   return (
     <div className="flex items-center justify-between bg-[rgba(47,58,76,0.06)] px-6 py-2 text-xs text-ink-muted">
       <span>
-        Keepr <strong>v{latestVersion}</strong> is available.{" "}
-        <span className="text-ink-faint">
-          Run{" "}
-          <code className="rounded bg-[rgba(10,10,10,0.06)] px-1 py-0.5 text-[10px]">
-            brew upgrade --cask keepr
-          </code>{" "}
-          to update.
-        </span>
+        Keepr <strong>v{state.version}</strong>{" "}
+        {state.kind === "ready" ? (
+          <span className="text-ink-faint">is ready to install. Restart Keepr to upgrade.</span>
+        ) : (
+          <span className="text-ink-faint">
+            is available. Run{" "}
+            <code className="rounded bg-[rgba(10,10,10,0.06)] px-1 py-0.5 text-[10px]">
+              brew upgrade --cask keepr
+            </code>{" "}
+            to update.
+          </span>
+        )}
       </span>
-      <button
-        onClick={() => setDismissed(true)}
-        className="ml-4 text-ink-faint transition-colors duration-180 hover:text-ink"
-        aria-label="Dismiss update notification"
-      >
-        ×
-      </button>
+      <div className="ml-4 flex items-center gap-3">
+        {state.kind === "ready" && (
+          <button
+            onClick={handleRestart}
+            disabled={restarting}
+            className="rounded bg-ink px-2 py-1 text-[11px] text-canvas hover:bg-ink-soft disabled:opacity-60"
+          >
+            {restarting ? "Restarting…" : "Restart to install"}
+          </button>
+        )}
+        <button
+          onClick={() => setDismissed(true)}
+          className="text-ink-faint transition-colors duration-180 hover:text-ink"
+          aria-label="Dismiss update notification"
+        >
+          ×
+        </button>
+      </div>
     </div>
   );
-}
-
-async function checkForUpdate(): Promise<string | null> {
-  // Check cache first.
-  try {
-    const cached = localStorage.getItem(STORAGE_KEY);
-    if (cached) {
-      const data: CachedCheck = JSON.parse(cached);
-      if (Date.now() - data.checkedAt < CHECK_INTERVAL_MS) {
-        return data.latestVersion;
-      }
-    }
-  } catch {
-    // Ignore cache errors.
-  }
-
-  // Fetch from GitHub.
-  try {
-    const response = await tauriFetch(GITHUB_API, {
-      method: "GET",
-      headers: {
-        Accept: "application/vnd.github.v3+json",
-        "User-Agent": "Keepr-Desktop",
-      },
-    });
-
-    if (!response.ok) return null;
-
-    const data = await response.json() as { tag_name?: string };
-    const version = data.tag_name?.replace(/^v/, "") || null;
-
-    // Cache the result.
-    const check: CachedCheck = {
-      checkedAt: Date.now(),
-      latestVersion: version,
-    };
-    localStorage.setItem(STORAGE_KEY, JSON.stringify(check));
-
-    return version;
-  } catch {
-    // Network errors are fine — silent no-op.
-    return null;
-  }
-}
-
-function isNewer(remote: string, current: string): boolean {
-  const r = remote.split(".").map(Number);
-  const c = current.split(".").map(Number);
-  for (let i = 0; i < 3; i++) {
-    if ((r[i] || 0) > (c[i] || 0)) return true;
-    if ((r[i] || 0) < (c[i] || 0)) return false;
-  }
-  return false;
 }

--- a/src/components/__tests__/UpdateBanner.test.tsx
+++ b/src/components/__tests__/UpdateBanner.test.tsx
@@ -1,0 +1,105 @@
+// UpdateBanner tests — view layer only. Logic lives in services/updater.ts
+// (covered separately). These tests assert the banner subscribes correctly,
+// renders the right message per state, and routes the Restart click.
+
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const checkForUpdateMock = vi.fn<() => Promise<any>>(async () => {});
+const relaunchMock = vi.fn<() => Promise<void>>(async () => {});
+let currentState: any = { kind: "idle" };
+const subscribers: Array<(s: any) => void> = [];
+
+function setStubState(next: any) {
+  currentState = next;
+  for (const s of subscribers) s(next);
+}
+
+vi.mock("../../services/updater", () => ({
+  getState: () => currentState,
+  subscribe: (fn: (s: any) => void) => {
+    subscribers.push(fn);
+    fn(currentState);
+    return () => {
+      const i = subscribers.indexOf(fn);
+      if (i >= 0) subscribers.splice(i, 1);
+    };
+  },
+  checkForUpdate: () => checkForUpdateMock(),
+}));
+
+vi.mock("@tauri-apps/plugin-process", () => ({
+  relaunch: () => relaunchMock(),
+}));
+
+import { UpdateBanner } from "../UpdateBanner";
+
+beforeEach(() => {
+  checkForUpdateMock.mockReset();
+  checkForUpdateMock.mockResolvedValue(undefined);
+  relaunchMock.mockReset();
+  relaunchMock.mockResolvedValue(undefined);
+  subscribers.length = 0;
+  currentState = { kind: "idle" };
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("UpdateBanner", () => {
+  it("renders nothing in idle state", () => {
+    const { container } = render(<UpdateBanner />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders nothing in current state", () => {
+    currentState = { kind: "current" };
+    const { container } = render(<UpdateBanner />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders the Restart button when state is ready", () => {
+    currentState = { kind: "ready", version: "0.2.6", update: { version: "0.2.6" } };
+    render(<UpdateBanner />);
+    expect(screen.getByText(/ready to install/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /restart to install/i })).toBeInTheDocument();
+  });
+
+  it("renders the brew-upgrade copy when state is fallback", () => {
+    currentState = { kind: "fallback", version: "0.2.6" };
+    render(<UpdateBanner />);
+    expect(screen.getByText(/brew upgrade --cask keepr/)).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /restart to install/i })).toBeNull();
+  });
+
+  it("invokes relaunch() when Restart is clicked", async () => {
+    currentState = { kind: "ready", version: "0.2.6", update: { version: "0.2.6" } };
+    render(<UpdateBanner />);
+    fireEvent.click(screen.getByRole("button", { name: /restart to install/i }));
+    // Allow microtasks to flush
+    await Promise.resolve();
+    expect(relaunchMock).toHaveBeenCalled();
+  });
+
+  it("dismiss hides the banner for the session", () => {
+    currentState = { kind: "ready", version: "0.2.6", update: { version: "0.2.6" } };
+    render(<UpdateBanner />);
+    fireEvent.click(screen.getByRole("button", { name: /dismiss/i }));
+    expect(screen.queryByText(/ready to install/i)).toBeNull();
+  });
+
+  it("calls checkForUpdate() on mount", () => {
+    render(<UpdateBanner />);
+    expect(checkForUpdateMock).toHaveBeenCalled();
+  });
+
+  it("re-renders when the singleton transitions to ready", () => {
+    const { container } = render(<UpdateBanner />);
+    expect(container.firstChild).toBeNull();
+    act(() => {
+      setStubState({ kind: "ready", version: "0.2.6", update: { version: "0.2.6" } });
+    });
+    expect(screen.getByText(/ready to install/i)).toBeInTheDocument();
+  });
+});

--- a/src/lib/version.ts
+++ b/src/lib/version.ts
@@ -1,0 +1,16 @@
+// Single source of truth for Keepr's running version on the JS side.
+// Vite injects __KEEPR_VERSION__ from package.json at build time; the
+// fallback only matters in unit tests where the define is absent.
+
+export const CURRENT_VERSION: string =
+  typeof __KEEPR_VERSION__ !== "undefined" ? __KEEPR_VERSION__ : "0.0.0";
+
+export function isNewer(remote: string, current: string): boolean {
+  const r = remote.split(".").map(Number);
+  const c = current.split(".").map(Number);
+  for (let i = 0; i < 3; i++) {
+    if ((r[i] || 0) > (c[i] || 0)) return true;
+    if ((r[i] || 0) < (c[i] || 0)) return false;
+  }
+  return false;
+}

--- a/src/screens/Settings.tsx
+++ b/src/screens/Settings.tsx
@@ -4,6 +4,13 @@ import { useEffect, useRef, useState } from "react";
 import { open as openDialog } from "@tauri-apps/plugin-dialog";
 import { open as openExternal } from "@tauri-apps/plugin-shell";
 import {
+  checkForUpdate,
+  getLastCheckedAt,
+  subscribe as subscribeUpdater,
+  type UpdaterState,
+} from "../services/updater";
+import { CURRENT_VERSION as APP_VERSION } from "../lib/version";
+import {
   getConfig,
   listMembers,
   setConfig,
@@ -898,6 +905,10 @@ export function Settings({
           </div>
         </Panel>
 
+        <Panel title="App">
+          <AppPanel />
+        </Panel>
+
         <Panel title="Experimental">
           <p className="mb-4 text-xs text-ink-faint">
             Toggle new features. All are enabled by default.
@@ -962,7 +973,68 @@ const PANEL_ICONS: Record<string, React.ReactNode> = {
       <path d="M5 10h6" stroke="currentColor" strokeWidth="1.1" strokeLinecap="round" />
     </svg>
   ),
+  App: (
+    <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden>
+      <rect x="2" y="2" width="12" height="12" rx="2.5" stroke="currentColor" strokeWidth="1.1" />
+      <path d="M5 8l2 2 4-4" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" strokeLinejoin="round" />
+    </svg>
+  ),
 };
+
+// App panel — current version + manual "Check for updates". The actual
+// check/download logic lives in services/updater.ts; this is just a
+// view onto its singleton so users impatient with the 6h auto-check
+// can poke it manually. Banner-driven UI stays in <UpdateBanner>.
+function AppPanel() {
+  const [updaterState, setUpdaterState] = useState<UpdaterState>({ kind: "idle" });
+  const [lastChecked, setLastChecked] = useState<string | null>(() => {
+    const ts = getLastCheckedAt();
+    return ts ? new Date(ts).toLocaleString() : null;
+  });
+
+  useEffect(() => {
+    return subscribeUpdater((s) => {
+      setUpdaterState(s);
+      const ts = getLastCheckedAt();
+      if (ts) setLastChecked(new Date(ts).toLocaleString());
+    });
+  }, []);
+
+  const onCheck = async () => {
+    // Force = bypass the session-running deferral. If the user clicked
+    // "Check for updates" manually, they want a result.
+    await checkForUpdate({ force: true });
+  };
+
+  const checking = updaterState.kind === "checking";
+  let message: string | null = null;
+  if (updaterState.kind === "ready") {
+    message = `v${updaterState.version} is downloaded. The banner will prompt to restart.`;
+  } else if (updaterState.kind === "fallback") {
+    message = `v${updaterState.version} is available. Run brew upgrade --cask keepr.`;
+  } else if (updaterState.kind === "current") {
+    message = `You're on the latest version (v${APP_VERSION}).`;
+  }
+
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="grid grid-cols-[120px_1fr] items-baseline gap-x-4 gap-y-2 text-xs">
+        <span className="text-ink-faint">Version</span>
+        <span className="mono text-ink">v{APP_VERSION}</span>
+        <span className="text-ink-faint">Channel</span>
+        <span className="mono text-ink">stable</span>
+        <span className="text-ink-faint">Last checked</span>
+        <span className="text-ink">{lastChecked || "never"}</span>
+      </div>
+      <div className="flex items-center gap-3 pt-1">
+        <Ghost onClick={onCheck} disabled={checking}>
+          {checking ? "Checking…" : "Check for updates"}
+        </Ghost>
+        {message && <span className="text-xs text-ink-soft">{message}</span>}
+      </div>
+    </div>
+  );
+}
 
 function Panel({ title, children }: { title: string; children: React.ReactNode }) {
   const icon = PANEL_ICONS[title];

--- a/src/screens/__tests__/Settings.test.tsx
+++ b/src/screens/__tests__/Settings.test.tsx
@@ -125,6 +125,10 @@ vi.mock("@tauri-apps/plugin-shell", () => ({
   open: vi.fn(),
 }));
 
+vi.mock("@tauri-apps/plugin-updater", () => ({
+  check: vi.fn(async () => null),
+}));
+
 vi.mock("../../components/primitives/SourceBadge", () => ({
   GitHubIcon: () => null,
   GitLabIcon: () => null,

--- a/src/services/__tests__/updater.test.ts
+++ b/src/services/__tests__/updater.test.ts
@@ -1,0 +1,183 @@
+// Updater singleton tests. The singleton is the brain — coalescing
+// concurrent callers, short-circuiting once we're ready, falling back
+// to GitHub-API on plugin failure, and protecting in-flight pulses.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const checkMock = vi.fn<() => Promise<any>>();
+const downloadAndInstallMock = vi.fn<() => Promise<void>>(async () => {});
+const dbSelectMock = vi.fn<(sql: string, params?: unknown) => Promise<Array<{ cnt: number }>>>(
+  async () => [{ cnt: 0 }]
+);
+const httpFetchMock = vi.fn<(url: string, init?: any) => Promise<any>>();
+
+vi.mock("@tauri-apps/plugin-updater", () => ({
+  check: () => checkMock(),
+}));
+
+vi.mock("@tauri-apps/plugin-http", () => ({
+  fetch: (url: string, init?: any) => httpFetchMock(url, init),
+}));
+
+vi.mock("../db", () => ({
+  db: vi.fn(async () => ({
+    select: (sql: string, params?: unknown) => dbSelectMock(sql, params),
+  })),
+}));
+
+import {
+  _resetForTests,
+  checkForUpdate,
+  getState,
+  subscribe,
+} from "../updater";
+
+function makeUpdate(version: string) {
+  return { version, downloadAndInstall: downloadAndInstallMock };
+}
+
+beforeEach(() => {
+  _resetForTests();
+  checkMock.mockReset();
+  downloadAndInstallMock.mockReset();
+  downloadAndInstallMock.mockResolvedValue(undefined);
+  dbSelectMock.mockReset();
+  dbSelectMock.mockResolvedValue([{ cnt: 0 }]);
+  httpFetchMock.mockReset();
+  localStorage.clear();
+  (globalThis as any).__KEEPR_VERSION__ = "0.2.5";
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("checkForUpdate — plugin path", () => {
+  it("transitions idle → ready when a newer update exists", async () => {
+    checkMock.mockResolvedValue(makeUpdate("0.2.6"));
+    const result = await checkForUpdate();
+    expect(result.kind).toBe("ready");
+    expect(downloadAndInstallMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("transitions to current when on latest version", async () => {
+    checkMock.mockResolvedValue(null);
+    const result = await checkForUpdate();
+    expect(result.kind).toBe("current");
+    expect(downloadAndInstallMock).not.toHaveBeenCalled();
+  });
+
+  it("returns ready immediately on second call (no re-download)", async () => {
+    checkMock.mockResolvedValue(makeUpdate("0.2.6"));
+    await checkForUpdate();
+    checkMock.mockClear();
+    downloadAndInstallMock.mockClear();
+    const result = await checkForUpdate();
+    expect(result.kind).toBe("ready");
+    expect(checkMock).not.toHaveBeenCalled();
+    expect(downloadAndInstallMock).not.toHaveBeenCalled();
+  });
+
+  it("coalesces concurrent callers into a single check + download", async () => {
+    // Hold the plugin call open so the three callers all attach to the
+    // same in-flight promise. Resolving once is enough for all three.
+    let resolveCheck!: (u: any) => void;
+    const checkPending = new Promise((r) => { resolveCheck = r; });
+    checkMock.mockImplementation(() => checkPending);
+    const a = checkForUpdate();
+    const b = checkForUpdate();
+    const c = checkForUpdate();
+    // Flush microtasks so the IIFE has reached `await check()` before
+    // we resolve. Without this, resolveCheck is still undefined.
+    await Promise.resolve();
+    await Promise.resolve();
+    resolveCheck(makeUpdate("0.2.6"));
+    const [ra, rb, rc] = await Promise.all([a, b, c]);
+    expect(ra).toBe(rb);
+    expect(rb).toBe(rc);
+    expect(checkMock).toHaveBeenCalledTimes(1);
+    expect(downloadAndInstallMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("checkForUpdate — fallback path", () => {
+  it("uses GitHub poll when plugin throws and surfaces fallback state", async () => {
+    checkMock.mockRejectedValue(new Error("plugin offline"));
+    httpFetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({ tag_name: "v0.2.6" }),
+    });
+    const result = await checkForUpdate();
+    expect(result.kind).toBe("fallback");
+    if (result.kind === "fallback") expect(result.version).toBe("0.2.6");
+  });
+
+  it("returns current when both plugin and fallback yield no newer version", async () => {
+    checkMock.mockRejectedValue(new Error("plugin offline"));
+    httpFetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({ tag_name: "v0.2.5" }),
+    });
+    const result = await checkForUpdate();
+    expect(result.kind).toBe("current");
+  });
+});
+
+describe("checkForUpdate — session safety", () => {
+  it("defers when an active session was created within the staleness window", async () => {
+    dbSelectMock.mockResolvedValue([{ cnt: 1 }]);
+    checkMock.mockResolvedValue(null);
+    const result = await checkForUpdate();
+    expect(result.kind).toBe("idle");
+    expect(checkMock).not.toHaveBeenCalled();
+  });
+
+  it("force=true bypasses the deferral so manual check always runs", async () => {
+    dbSelectMock.mockResolvedValue([{ cnt: 1 }]);
+    checkMock.mockResolvedValue(null);
+    const result = await checkForUpdate({ force: true });
+    expect(result.kind).toBe("current");
+    expect(checkMock).toHaveBeenCalled();
+  });
+
+  it("ignores stale processing rows so a crashed pulse can't permanently block updates", async () => {
+    // The query selects only sessions with created_at > cutoff. Mock
+    // returns 0 — meaning no recent active sessions even if old rows
+    // exist with status='processing'.
+    dbSelectMock.mockImplementation(async (sql: string) => {
+      // Verify the query has the staleness guard
+      expect(sql).toMatch(/created_at > /);
+      return [{ cnt: 0 }];
+    });
+    checkMock.mockResolvedValue(null);
+    const result = await checkForUpdate();
+    expect(result.kind).toBe("current");
+  });
+});
+
+describe("subscribe", () => {
+  it("notifies subscribers of state transitions", async () => {
+    const observed: string[] = [];
+    const unsubscribe = subscribe((s) => observed.push(s.kind));
+    checkMock.mockResolvedValue(makeUpdate("0.2.6"));
+    await checkForUpdate();
+    unsubscribe();
+    // Initial idle, then checking, then ready.
+    expect(observed).toEqual(["idle", "checking", "ready"]);
+  });
+
+  it("unsubscribe stops further updates", async () => {
+    let count = 0;
+    const unsub = subscribe(() => { count++; });
+    unsub();
+    checkMock.mockResolvedValue(null);
+    await checkForUpdate();
+    expect(count).toBe(1); // only the initial replay
+  });
+});
+
+describe("getState", () => {
+  it("starts at idle", () => {
+    expect(getState().kind).toBe("idle");
+  });
+});

--- a/src/services/updater.ts
+++ b/src/services/updater.ts
@@ -1,0 +1,193 @@
+// Updater singleton — one source of truth shared between <UpdateBanner>
+// and the Settings App panel. Without this, both surfaces independently
+// call check() + downloadAndInstall() and we end up downloading the
+// same multi-MB bundle twice (or worse, racing two installs to the same
+// temp dir).
+//
+// The state machine:
+//
+//   ┌───────┐  check()  ┌─────────┐  downloadAndInstall()  ┌─────────┐
+//   │ idle  │──────────▶│ checking│───────────────────────▶│  ready  │
+//   └───────┘           └─────────┘                        └─────────┘
+//        │                   │                                 │
+//        │                   ▼                                 ▼
+//        │              ┌─────────┐                       relaunch()
+//        └─────────────▶│fallback │
+//                       └─────────┘
+//
+// Once we reach `ready`, no further check()/download() calls fire — we
+// just stay in ready until the user clicks Restart and the app relaunches
+// into the new version.
+//
+// `fallback` is the legacy GitHub-API path used when the plugin can't
+// initialize (offline, signature failure, etc). It does not download —
+// it just surfaces the "run brew upgrade" copy.
+
+import { fetch as tauriFetch } from "@tauri-apps/plugin-http";
+import { check, type Update } from "@tauri-apps/plugin-updater";
+import { db } from "./db";
+import { CURRENT_VERSION, isNewer } from "../lib/version";
+
+export type UpdaterState =
+  | { kind: "idle" }
+  | { kind: "checking" }
+  | { kind: "ready"; version: string; update: Update }
+  | { kind: "fallback"; version: string }
+  | { kind: "current" };
+
+const FALLBACK_CACHE_MS = 24 * 60 * 60 * 1000;
+const STALE_SESSION_MS = 60 * 60 * 1000; // 1h — protects against crashed pulses
+const STORAGE_KEY = "keepr_update_check";
+const TIMESTAMP_KEY = "keepr_update_check_ts";
+const GITHUB_API = "https://api.github.com/repos/keeprlabs/keepr/releases/latest";
+
+let state: UpdaterState = { kind: "idle" };
+let inflight: Promise<UpdaterState> | null = null;
+const subscribers = new Set<(s: UpdaterState) => void>();
+
+export function getState(): UpdaterState {
+  return state;
+}
+
+export function subscribe(fn: (s: UpdaterState) => void): () => void {
+  subscribers.add(fn);
+  fn(state);
+  return () => {
+    subscribers.delete(fn);
+  };
+}
+
+function setState(next: UpdaterState): void {
+  state = next;
+  for (const fn of subscribers) fn(state);
+}
+
+/**
+ * Run a check + (if newer) silent download. Concurrent callers share the
+ * same in-flight promise. If the state is already `ready`, returns
+ * immediately — no re-checking, no re-downloading.
+ *
+ * @param force when true, bypasses the "already ready" short-circuit so a
+ *              user clicking "Check for updates" gets a fresh probe.
+ */
+export function checkForUpdate(opts: { force?: boolean } = {}): Promise<UpdaterState> {
+  // Already done — short-circuit. No re-check, no re-download.
+  if (state.kind === "ready") return Promise.resolve(state);
+  // Already in flight — return the same promise so concurrent callers share work.
+  if (inflight) return inflight;
+
+  // Set inflight synchronously so a second call entering before the first
+  // even starts its awaits hits the dedup branch above. Without this, each
+  // caller would race its own session-check + check() pair.
+  inflight = (async (): Promise<UpdaterState> => {
+    try {
+      if (!opts.force && (await isSessionRunning())) {
+        return state; // defer entirely while a pulse is processing
+      }
+      setState({ kind: "checking" });
+      try {
+        const update = await check();
+        if (!update || !isNewer(update.version, CURRENT_VERSION)) {
+          setState({ kind: "current" });
+          recordTimestamp();
+          return state;
+        }
+        // Silent download — banner only appears once the bundle is ready.
+        await update.downloadAndInstall();
+        setState({ kind: "ready", version: update.version, update });
+        recordTimestamp();
+        return state;
+      } catch (err) {
+        console.warn("Updater plugin check failed; falling back to GitHub poll:", err);
+        const fallbackVersion = await pollGitHubReleases();
+        if (fallbackVersion && isNewer(fallbackVersion, CURRENT_VERSION)) {
+          setState({ kind: "fallback", version: fallbackVersion });
+        } else {
+          setState({ kind: "current" });
+        }
+        recordTimestamp();
+        return state;
+      }
+    } finally {
+      inflight = null;
+    }
+  })();
+  return inflight;
+}
+
+export function getLastCheckedAt(): number | null {
+  try {
+    const raw = localStorage.getItem(TIMESTAMP_KEY);
+    return raw ? Number.parseInt(raw, 10) : null;
+  } catch {
+    return null;
+  }
+}
+
+function recordTimestamp(): void {
+  try {
+    localStorage.setItem(TIMESTAMP_KEY, String(Date.now()));
+  } catch {
+    /* ignore */
+  }
+}
+
+async function pollGitHubReleases(): Promise<string | null> {
+  try {
+    const cached = localStorage.getItem(STORAGE_KEY);
+    if (cached) {
+      const data = JSON.parse(cached) as { checkedAt?: number; latestVersion?: string | null };
+      if (data.checkedAt && Date.now() - data.checkedAt < FALLBACK_CACHE_MS) {
+        return data.latestVersion ?? null;
+      }
+    }
+  } catch {
+    /* bad cache — fall through */
+  }
+  try {
+    const response = await tauriFetch(GITHUB_API, {
+      method: "GET",
+      headers: {
+        Accept: "application/vnd.github.v3+json",
+        "User-Agent": "Keepr-Desktop",
+      },
+    });
+    if (!response.ok) return null;
+    const data = (await response.json()) as { tag_name?: string };
+    const version = data.tag_name?.replace(/^v/, "") || null;
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({ checkedAt: Date.now(), latestVersion: version })
+    );
+    return version;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * A pulse is "running" only if at least one session is in 'processing'
+ * AND was created within the staleness window. Older rows are treated as
+ * crashed pulses — without this, a single crash permanently blocks
+ * updates for that user.
+ */
+async function isSessionRunning(): Promise<boolean> {
+  try {
+    const d = await db();
+    const cutoff = new Date(Date.now() - STALE_SESSION_MS).toISOString();
+    const rows = await d.select<Array<{ cnt: number }>>(
+      "SELECT COUNT(*) as cnt FROM sessions WHERE status = 'processing' AND created_at > ?",
+      [cutoff]
+    );
+    return (rows[0]?.cnt ?? 0) > 0;
+  } catch {
+    return false;
+  }
+}
+
+// Test helper — resets the singleton between tests.
+export function _resetForTests(): void {
+  state = { kind: "idle" };
+  inflight = null;
+  subscribers.clear();
+}

--- a/src/test-setup.ts
+++ b/src/test-setup.ts
@@ -5,3 +5,8 @@ import "@testing-library/jest-dom/vitest";
 if (typeof Element !== "undefined" && !Element.prototype.scrollIntoView) {
   Element.prototype.scrollIntoView = function () {};
 }
+
+// Vite injects __KEEPR_VERSION__ from package.json at build time. In tests
+// we set it once before any module imports run so version-comparison code
+// in src/lib/version.ts and friends sees a real value rather than "0.0.0".
+(globalThis as any).__KEEPR_VERSION__ = "0.2.5";


### PR DESCRIPTION
Pulls the auto-updater work from main into the ctxd integration branch so both ship together. Four conflicts resolved (release.yml, CHANGES.md, Settings.tsx, Cargo.lock). 358 vitest + 20 cargo passing.