### PR TITLE
fix: propagate user shell PATH so Codex shebang can find node

### DIFF
--- a/src-tauri/src/binresolve.rs
+++ b/src-tauri/src/binresolve.rs
@@ -18,6 +18,21 @@ use std::process::Command;
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
 
+use serde::Serialize;
+
+/// Resolved binary plus the user's shell `$PATH` so spawn callers can pass it
+/// through to subprocess env. Without `env_path`, npm-installed CLIs whose
+/// shebang is `#!/usr/bin/env node` fail with "env: node: No such file" when
+/// the GUI app's minimal Launch Services PATH doesn't include the user's
+/// node directory (nvm, asdf, mise, fnm, custom prefix). Capturing PATH from
+/// the same login-shell call that resolved the binary keeps us to a single
+/// expensive shell spawn per binary.
+#[derive(Debug, Serialize, Clone)]
+pub struct ResolvedBinary {
+    pub path: String,
+    pub env_path: String,
+}
+
 /// Reject anything that isn't a plain CLI name. Defense-in-depth — the only
 /// caller is the JS layer, which passes literal "codex" / "claude" today, but
 /// if a future caller passes user input we don't want shell injection.
@@ -29,8 +44,16 @@ fn is_safe_bin_name(name: &str) -> bool {
             .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_' || c == '.')
 }
 
+/// Markers we emit to delimit our two output values from any rc-file noise
+/// (oh-my-zsh update notices, direnv reload messages, starship transient
+/// prompts, etc.). Marker-delimiting both fields means parsing is robust
+/// against any line of stdout we didn't print ourselves — we just match
+/// the prefix and ignore everything else.
+const PATH_MARKER: &str = "__KEEPR_ENV_PATH__=";
+const BIN_MARKER: &str = "__KEEPR_BIN__=";
+
 #[tauri::command]
-pub fn resolve_binary(name: String) -> Option<String> {
+pub fn resolve_binary(name: String) -> Option<ResolvedBinary> {
     if !is_safe_bin_name(&name) {
         return None;
     }
@@ -45,7 +68,19 @@ pub fn resolve_binary(name: String) -> Option<String> {
     // -i: interactive shell (sources .zshrc / .bashrc)
     // `command -v <name>` is POSIX-portable across zsh/bash/dash. `2>/dev/null`
     // suppresses the rc-file noise some users emit on every shell init.
-    let script = format!("command -v {} 2>/dev/null", name);
+    //
+    // We marker-delimit both outputs so the parser doesn't depend on output
+    // ordering (rc files can print on prompt render, exit hooks, etc.).
+    // printf with markers as DATA arguments (not embedded in the format
+    // string) — defense-in-depth so a marker change can never accidentally
+    // introduce a printf-format vulnerability.
+    let script = format!(
+        "printf '%s%s\\n' '{path_marker}' \"$PATH\"; \
+         printf '%s%s\\n' '{bin_marker}' \"$(command -v {name} 2>/dev/null)\"",
+        path_marker = PATH_MARKER,
+        bin_marker = BIN_MARKER,
+        name = name,
+    );
 
     let output = Command::new(&shell)
         .args(["-lic", &script])
@@ -53,13 +88,27 @@ pub fn resolve_binary(name: String) -> Option<String> {
         .ok()?;
 
     let stdout = String::from_utf8_lossy(&output.stdout);
-    let path = stdout.lines().last()?.trim().to_string();
 
+    // Parse: pull each marker prefix, ignore anything else. Position-
+    // independent — rc-file noise interleaved with our prints is dropped.
+    let mut env_path = String::new();
+    let mut path = String::new();
+    for line in stdout.lines() {
+        if let Some(rest) = line.strip_prefix(PATH_MARKER) {
+            env_path = rest.trim().to_string();
+        } else if let Some(rest) = line.strip_prefix(BIN_MARKER) {
+            path = rest.trim().to_string();
+        }
+    }
+
+    // Conservative rejection: paths with whitespace or that are empty mean
+    // either `command -v` returned nothing, or the shell printed an alias /
+    // function definition / multi-word string. None of those are usable.
     if path.is_empty() || path.contains(char::is_whitespace) {
         return None;
     }
 
-    Some(path)
+    Some(ResolvedBinary { path, env_path })
 }
 
 /// Detect a macOS .app bundle for a given CLI provider name. Used as a
@@ -242,9 +291,31 @@ mod tests {
         // by name via this very mechanism. Smoke test that the helper at least
         // executes and returns *something* plausible for a guaranteed binary.
         let result = resolve_binary("sh".to_string());
-        if let Some(path) = result {
-            assert!(path.starts_with('/'), "path should be absolute: {}", path);
-            assert!(path.ends_with("sh") || path.ends_with("dash"), "got: {}", path);
+        if let Some(resolved) = result {
+            assert!(
+                resolved.path.starts_with('/'),
+                "path should be absolute: {}",
+                resolved.path
+            );
+            assert!(
+                resolved.path.ends_with("sh") || resolved.path.ends_with("dash"),
+                "got: {}",
+                resolved.path
+            );
+            // env_path should be non-empty and contain at least one common
+            // system bin directory. We can't assert on user-specific paths
+            // (nvm, homebrew) because CI runners vary, but every Unix has
+            // /bin or /usr/bin.
+            assert!(
+                !resolved.env_path.is_empty(),
+                "env_path should be populated: {:?}",
+                resolved.env_path
+            );
+            assert!(
+                resolved.env_path.contains("/bin") || resolved.env_path.contains("/usr"),
+                "env_path missing common system dirs: {:?}",
+                resolved.env_path
+            );
         }
         // If None, the test environment doesn't have an interactive shell at
         // all (rare CI sandbox) — not a failure of the helper itself.

--- a/src/services/__tests__/llm.spawn.test.ts
+++ b/src/services/__tests__/llm.spawn.test.ts
@@ -685,6 +685,69 @@ describe("resolveBinary [regression: GUI app PATH not_in_path bug]", () => {
     expect(cmdLine).toMatch(/< \/dev\/null$/);
   });
 
+  it("exports user shell PATH inside the wrapper script so Node-shebang CLIs find `node`", async () => {
+    // Regression: nvm/asdf/mise install codex with shebang `#!/usr/bin/env
+    // node`. The GUI app's Launch Services PATH doesn't see the user's nvm
+    // node directory, so `env node` fails 127 with "No such file or
+    // directory" — and classifyCliError flagged the probe as "not_installed".
+    // Fix: pass the user's shell $PATH (captured by `resolve_binary` in the
+    // same login-shell call) and prepend an `export PATH=...` to the wrapper
+    // so child shebangs resolve.
+    const userPath = "/Users/me/.nvm/versions/node/v22.22.0/bin:/opt/homebrew/bin:/usr/bin:/bin";
+    invokeMock.mockImplementation(async (cmd: string, args?: any) => {
+      if (cmd === "resolve_binary" && args?.name === "codex") {
+        return {
+          path: "/Users/me/.nvm/versions/node/v22.22.0/bin/codex",
+          env_path: userPath,
+        };
+      }
+      return null;
+    });
+    FakeCommand.plan = { stdout: [], exitCode: 0 };
+    const fs = await import("@tauri-apps/plugin-fs");
+    (fs.readTextFile as any).mockResolvedValueOnce("ok");
+
+    await PROVIDERS.codex.complete({
+      model: "gpt-5.4",
+      messages: [{ role: "user", content: "x" }],
+    });
+
+    const cmdLine = FakeCommand.lastInstance?.args?.[1] || "";
+    // PATH export must come before exec so the shebang lookup uses it. We
+    // EXTEND `$PATH` rather than replace it — that way a partial envPath
+    // can't silently strip /usr/bin from the spawned child's lookup.
+    expect(cmdLine).toMatch(/^export PATH='[^']+':"\$PATH"; exec /);
+    expect(cmdLine).toContain(userPath);
+    // And the actual codex invocation still uses the absolute path.
+    expect(cmdLine).toContain("'/Users/me/.nvm/versions/node/v22.22.0/bin/codex'");
+    expect(cmdLine).toMatch(/< \/dev\/null$/);
+  });
+
+  it("omits PATH export when envPath is empty (resolve_binary returned no PATH)", async () => {
+    // Defensive: if the Rust side ever returns env_path:"" (e.g. login shell
+    // failed to print PATH), the wrapper must NOT emit `export PATH=''`
+    // because that would clobber the inherited PATH and break /usr/bin
+    // lookups for everything spawned afterward.
+    invokeMock.mockImplementation(async (cmd: string, args?: any) => {
+      if (cmd === "resolve_binary" && args?.name === "codex") {
+        return { path: "/opt/homebrew/bin/codex", env_path: "" };
+      }
+      return null;
+    });
+    FakeCommand.plan = { stdout: [], exitCode: 0 };
+    const fs = await import("@tauri-apps/plugin-fs");
+    (fs.readTextFile as any).mockResolvedValueOnce("ok");
+
+    await PROVIDERS.codex.complete({
+      model: "gpt-5.4",
+      messages: [{ role: "user", content: "x" }],
+    });
+
+    const cmdLine = FakeCommand.lastInstance?.args?.[1] || "";
+    expect(cmdLine).not.toContain("export PATH");
+    expect(cmdLine).toMatch(/^exec '\/opt\/homebrew\/bin\/codex' /);
+  });
+
   it("caches the resolved path — second probe doesn't re-invoke resolve_binary", async () => {
     invokeMock.mockImplementation(async (cmd: string, args?: any) => {
       if (cmd === "resolve_binary") return `/usr/local/bin/${args?.name}`;
@@ -871,6 +934,37 @@ describe("resolveBinary — Settings path override", () => {
     expect(cmdLine).toMatch(/^exec '\/Users\/me\/dev\/codex-fork\/codex' /);
     // Anti-regression: shell resolution must NOT have been used.
     expect(cmdLine).not.toMatch(/'\/usr\/bin\/codex'/);
+  });
+
+  it("override path emits no `export PATH` (override doesn't capture user shell PATH)", async () => {
+    // The override path goes through validate_binary_path, which is pure
+    // file-stat validation — no login shell, no PATH capture. envPath is
+    // empty in that case, so the wrapper must NOT emit an `export PATH`
+    // line that would clobber the inherited PATH for everything spawned
+    // afterward (breaking /usr/bin lookups). User chose the override
+    // explicitly; if their binary needs PATH for a shebang, that's on them.
+    getConfigMock.mockImplementation(async () => ({
+      codex_cli_path: "/opt/myco/bin/codex",
+      claude_code_cli_path: "",
+    }));
+    invokeMock.mockImplementation(async (cmd: string, args?: any) => {
+      if (cmd === "validate_binary_path") {
+        return args?.path === "/opt/myco/bin/codex" ? "/opt/myco/bin/codex" : null;
+      }
+      return null;
+    });
+    FakeCommand.plan = { stdout: [], exitCode: 0 };
+    const fs = await import("@tauri-apps/plugin-fs");
+    (fs.readTextFile as any).mockResolvedValueOnce("ok");
+
+    await PROVIDERS.codex.complete({
+      model: "gpt-5.4",
+      messages: [{ role: "user", content: "x" }],
+    });
+
+    const cmdLine = FakeCommand.lastInstance?.args?.[1] || "";
+    expect(cmdLine).not.toContain("export PATH");
+    expect(cmdLine).toMatch(/^exec '\/opt\/myco\/bin\/codex' /);
   });
 
   it("broken override falls through to shell resolution (NOT throw)", async () => {

--- a/src/services/llm.ts
+++ b/src/services/llm.ts
@@ -356,18 +356,41 @@ interface RunCliOpts {
   /** Per-line callback for stdout (used for NDJSON event streams). The raw
    *  stdout is also captured in the return value. */
   onStdoutLine?: (line: string) => void;
+  /** When set on `runCliShellWrapped`, exported as `PATH=<envPath>:$PATH`
+   *  inside the shell wrapper before exec. Lets Node-shebang CLIs (Codex)
+   *  find `node` from the user's nvm/asdf/mise install when the GUI app's
+   *  Launch Services PATH doesn't see it. Ignored by `runCli` (no shell
+   *  wrapper to inject into). */
+  envPath?: string;
 }
 
 // ---- Absolute-path resolution for CLI binaries -----------------------------
 
-/** Cache of resolved absolute paths, keyed by binary name. macOS GUI apps
- *  inherit a minimal PATH from Launch Services, so `sh -c 'exec codex'` fails
- *  with "codex: not found" even when the binary works in Terminal. The Rust
- *  command resolves via the user's login+interactive shell so we get the same
- *  PATH the user sees in Terminal, then we cache the absolute path and use it
- *  directly — PATH stops mattering. Same lifetime as _codexProbeCache; cleared
- *  by invalidateCodexProbe / invalidateClaudeProbe. */
-const _binPathCache = new Map<string, string>();
+/** Resolved binary descriptor: absolute path AND the user's shell `$PATH`.
+ *  We need PATH because Codex (and other npm-installed Node CLIs) ship with
+ *  a `#!/usr/bin/env node` shebang — and `env` looks up `node` on the PATH
+ *  of the spawned process, not on the binary's own path. nvm/asdf/mise put
+ *  node in user-specific dirs that aren't on the GUI app's minimal Launch
+ *  Services PATH, so spawn fails with "env: node: No such file" and the old
+ *  classifier showed "Codex CLI not installed" — even though codex was
+ *  installed. */
+interface ResolvedBinary {
+  path: string;
+  /** User's shell `$PATH` from the same login shell that resolved `path`.
+   *  Empty when resolution came from a source that doesn't see PATH (e.g.
+   *  the Settings override path through validate_binary_path). */
+  envPath: string;
+}
+
+/** Cache of resolved absolute paths + envPath, keyed by binary name. macOS
+ *  GUI apps inherit a minimal PATH from Launch Services, so `sh -c 'exec
+ *  codex'` fails with "codex: not found" — and even after we resolve the
+ *  absolute path, Node-shebang scripts can't find `node` without PATH. The
+ *  Rust command resolves via the user's login+interactive shell so we get
+ *  the same PATH the user sees in Terminal; we cache and pass it through
+ *  to subsequent spawns. Same lifetime as _codexProbeCache; cleared by
+ *  invalidateCodexProbe / invalidateClaudeProbe. */
+const _binResolveCache = new Map<string, ResolvedBinary>();
 
 /** Session-level guard: have we already loaded the user's saved CLI-path
  *  override from app_config for this binary name? Avoids hitting SQLite
@@ -419,7 +442,7 @@ class AppOnlyNoCliError extends Error {
  *    - NotInPathError: shell can't find the CLI AND no .app bundle present.
  *      Either truly not installed or hidden in some non-standard location.
  *      Surface as the install-or-symlink message. */
-async function resolveBinary(name: string): Promise<string> {
+async function resolveBinary(name: string): Promise<ResolvedBinary> {
   // 0. User override from Settings — checked once per session per name.
   //    A broken/stale override falls through to shell + bundle detection
   //    (rather than throwing) so a moved binary auto-recovers via PATH.
@@ -435,8 +458,14 @@ async function resolveBinary(name: string): Promise<string> {
             path: userPath,
           });
           if (validated) {
-            _binPathCache.set(name, validated);
-            return validated;
+            // Override path skips shell, so we don't have the user's PATH.
+            // Empty envPath means the spawn falls back to the GUI's minimal
+            // PATH — which is fine for self-contained binaries (the user
+            // chose this path explicitly), and for Node shebangs the override
+            // path is the user's escape hatch when auto-detect fails anyway.
+            const resolved: ResolvedBinary = { path: validated, envPath: "" };
+            _binResolveCache.set(name, resolved);
+            return resolved;
           }
           // userPath is stored but no longer points at a valid executable.
           // Fall through to auto-detect. The probe surfaces this state via
@@ -450,20 +479,24 @@ async function resolveBinary(name: string): Promise<string> {
     }
   }
 
-  const cached = _binPathCache.get(name);
+  const cached = _binResolveCache.get(name);
   if (cached) return cached;
-  let path: string | null = null;
+  let raw: unknown = null;
   try {
-    path = await invoke<string | null>("resolve_binary", { name });
+    raw = await invoke<unknown>("resolve_binary", { name });
   } catch {
     // Tauri context not available (test env without invoke mock, or invoke
     // command failed to register). Fall through to the bare-name fallback —
     // production builds always have invoke; tests mock it explicitly.
-    return name;
+    return { path: name, envPath: "" };
   }
-  if (path) {
-    _binPathCache.set(name, path);
-    return path;
+  // Rust returns Option<ResolvedBinary> = { path, env_path }. Older test
+  // mocks return a bare string; tolerate both so we don't have to mass-
+  // edit every test fixture and still ship the env propagation in prod.
+  const resolved = normalizeResolvedBinary(raw);
+  if (resolved) {
+    _binResolveCache.set(name, resolved);
+    return resolved;
   }
   // Shell couldn't resolve — check the known .app bundle locations before
   // declaring it not-installed. If the user has the desktop app, we want to
@@ -478,19 +511,47 @@ async function resolveBinary(name: string): Promise<string> {
   throw new NotInPathError(name);
 }
 
+/** Coerce the `resolve_binary` IPC return into our ResolvedBinary shape, or
+ *  null if the Rust side returned None / something unparseable. Accepts the
+ *  new struct shape (`{ path, env_path }` — Rust serde snake_case) and a
+ *  bare string (legacy test fixtures only). One canonical contract. */
+function normalizeResolvedBinary(raw: unknown): ResolvedBinary | null {
+  if (raw == null) return null;
+  if (typeof raw === "string") {
+    return raw ? { path: raw, envPath: "" } : null;
+  }
+  if (typeof raw === "object") {
+    const r = raw as { path?: unknown; env_path?: unknown };
+    const path = typeof r.path === "string" ? r.path : "";
+    if (!path) return null;
+    const envPath = typeof r.env_path === "string" ? r.env_path : "";
+    return { path, envPath };
+  }
+  return null;
+}
+
 /** Drop the resolved-path cache for a single binary AND the session-level
  *  override-checked flag. Called from invalidateCodexProbe /
  *  invalidateClaudeProbe so the next probe re-resolves after the user
  *  installs the CLI, moves it into PATH, or saves a new override path
  *  via Settings. */
 function invalidateBinaryPath(name: string): void {
-  _binPathCache.delete(name);
+  _binResolveCache.delete(name);
   _overrideCheckedThisSession.delete(name);
 }
 
-/** Test-only: read the resolved-path cache without triggering a resolve. */
+/** Test-only: read the resolved-path cache without triggering a resolve.
+ *  Returns just the path for backward-compat with existing tests; tests
+ *  that need to inspect envPath should use `_peekBinaryResolveCache`. */
 export function _peekBinaryPathCache(name: string): string | null {
-  return _binPathCache.get(name) ?? null;
+  return _binResolveCache.get(name)?.path ?? null;
+}
+
+/** Test-only: read the full ResolvedBinary cache entry. */
+export function _peekBinaryResolveCache(
+  name: string,
+): { path: string; envPath: string } | null {
+  return _binResolveCache.get(name) ?? null;
 }
 
 /** POSIX shell single-quote any string. Wraps the input in `'...'` and
@@ -516,14 +577,31 @@ function shQuote(s: string): string {
  *  - `< /dev/null` gives the CLI an immediate EOF on stdin so it stops
  *    waiting for input.
  *
- *  Returns the same shape as runCli, just spawned through sh. */
+ *  Returns the same shape as runCli, just spawned through sh.
+ *
+ *  opts.envPath: when set, prepended to PATH inside the shell wrapper before
+ *  exec, so child processes (notably `env node` for Codex's Node-shebang
+ *  script) can find their dependencies. Extends rather than replaces — that
+ *  way a partial envPath (or one that drops some system dirs) can't silently
+ *  strip /usr/bin or /bin from the spawned child's lookup. We export inside
+ *  the script rather than passing via `opts.env` because the Tauri shell
+ *  plugin's `env` option REPLACES the process env on Unix, which would drop
+ *  HOME/USER/TERM/locale and break CLIs that expect a normal env. */
 async function runCliShellWrapped(
   program: string,
   args: string[],
   opts: RunCliOpts = {}
 ): Promise<RunCliResult> {
-  const cmdLine = "exec " + [program, ...args].map(shQuote).join(" ") + " < /dev/null";
-  return runCli("sh", ["-c", cmdLine], opts);
+  const { envPath, ...runOpts } = opts;
+  const exportPath = envPath
+    ? `export PATH=${shQuote(envPath)}:"$PATH"; `
+    : "";
+  const cmdLine =
+    exportPath +
+    "exec " +
+    [program, ...args].map(shQuote).join(" ") +
+    " < /dev/null";
+  return runCli("sh", ["-c", cmdLine], runOpts);
 }
 
 interface RunCliResult {
@@ -688,7 +766,7 @@ const claudeCode: LLMProvider = {
     }
     args.push(userContent);
 
-    const claudeBin = await resolveBinary("claude");
+    const claude = await resolveBinary("claude");
     // Wrapped through `sh -c 'exec <path> ... < /dev/null'` for two reasons:
     //   1. Tauri's shell:allow-spawn capability matches by program name. The
     //      allowlist whitelists "claude" — passing /opt/homebrew/bin/claude
@@ -696,9 +774,10 @@ const claudeCode: LLMProvider = {
     //      means Tauri only sees `sh` (allowed); the absolute path is just
     //      a string inside the script, never matched against the allowlist.
     //   2. Symmetry with codex.complete (already wrapped for stdin-EOF).
-    const result = await runCliShellWrapped(claudeBin, args, {
+    const result = await runCliShellWrapped(claude.path, args, {
       env: CLAUDE_SPAWN_ENV,
       signal: opts.signal,
+      envPath: claude.envPath,
     });
     if (result.code !== 0) {
       const msg = result.stderr || result.stdout || "claude exited with code " + result.code;
@@ -864,9 +943,10 @@ const codex: LLMProvider = {
       // Wrapped in sh so stdin is closed (`< /dev/null`) — codex would
       // otherwise block forever waiting for stdin EOF. See runCliShellWrapped.
       // Absolute path so the spawn doesn't depend on the GUI app's minimal PATH.
-      const codexBin = await resolveBinary("codex");
-      const result = await runCliShellWrapped(codexBin, args, {
+      const codex = await resolveBinary("codex");
+      const result = await runCliShellWrapped(codex.path, args, {
         signal: opts.signal,
+        envPath: codex.envPath,
         onStdoutLine: (line) => {
           // Tauri may emit a chunk with embedded newlines; split on \n so the
           // NDJSON parser sees one event per entry.
@@ -937,9 +1017,9 @@ export async function probeClaudeCode(force = false): Promise<ProbeResult> {
   const promise = (async (): Promise<ProbeResult> => {
     const args = ["--print", "--model", "haiku", "Reply with just: ok"];
     let result: RunCliResult;
-    let claudeBin: string;
+    let claude: ResolvedBinary;
     try {
-      claudeBin = await resolveBinary("claude");
+      claude = await resolveBinary("claude");
     } catch (e: any) {
       const raw = String(e?.message || e);
       let r: ProbeResult;
@@ -956,7 +1036,10 @@ export async function probeClaudeCode(force = false): Promise<ProbeResult> {
     try {
       // sh-wrapped so an absolute path doesn't trip the shell:allow-spawn
       // capability check. See claudeCode.complete for the full reasoning.
-      result = await runCliShellWrapped(claudeBin, args, { env: CLAUDE_SPAWN_ENV });
+      result = await runCliShellWrapped(claude.path, args, {
+        env: CLAUDE_SPAWN_ENV,
+        envPath: claude.envPath,
+      });
     } catch (e: any) {
       const r: ProbeResult = classifyCliError(String(e?.message || e), "claude");
       _claudeProbeCache = r;
@@ -1022,9 +1105,9 @@ export async function probeCodex(force = false): Promise<ProbeResult> {
         "Reply with just: ok",
       ];
       let result: RunCliResult;
-      let codexBin: string;
+      let codex: ResolvedBinary;
       try {
-        codexBin = await resolveBinary("codex");
+        codex = await resolveBinary("codex");
       } catch (e: any) {
         const raw = String(e?.message || e);
         let r: ProbeResult;
@@ -1040,8 +1123,13 @@ export async function probeCodex(force = false): Promise<ProbeResult> {
       }
       try {
         // Same sh-wrapper trick as codex.complete: codex would hang waiting
-        // for stdin EOF on a Tauri-spawned pipe.
-        result = await runCliShellWrapped(codexBin, args);
+        // for stdin EOF on a Tauri-spawned pipe. envPath threaded through so
+        // codex's `#!/usr/bin/env node` shebang can find node — without it,
+        // nvm/asdf/mise installs of codex fail with "env: node: No such file"
+        // and the classifier surfaces "Codex CLI not installed" misleadingly.
+        result = await runCliShellWrapped(codex.path, args, {
+          envPath: codex.envPath,
+        });
       } catch (e: any) {
         // runCli throws when the spawn itself fails (binary missing), so the
         // error message carries "command not found" or similar.


### PR DESCRIPTION
## Summary
- Settings → Codex was showing **"Codex CLI not installed"** even after `npm install -g @openai/codex`. Root cause: the previous fix (08068b3) resolved Codex's absolute path correctly, but the spawned `sh -c 'exec /…/codex …'` wrapper inherited the GUI app's minimal Launch Services PATH. Codex's shebang `#!/usr/bin/env node` couldn't find `node` (nvm/asdf/mise install it in user-specific dirs) → exit 127 with stderr `"env: node: No such file"` → `classifyCliError` mapped that to `not_installed`.
- Capture the user's shell `$PATH` from the same login-shell call that already resolves the binary, and prepend it (extending, not replacing) to PATH inside the wrapper script before exec. One shell spawn gets both path + PATH.
- Marker-delimit both outputs in the Rust shell script (`__KEEPR_BIN__=`, `__KEEPR_ENV_PATH__=`) so rc-file noise (oh-my-zsh update notices, direnv reload messages, starship transient prompts) can't corrupt parsing.

## Why extend PATH, not replace
`export PATH='<envPath>':"$PATH"`, not `export PATH='<envPath>'`. Replacing would silently strip `/usr/bin` if `envPath` were ever partial — extending costs nothing and removes a footgun.

## Why export inside the script vs. opts.env
The Tauri shell plugin's `env` option REPLACES the process env on Unix, dropping HOME/USER/TERM/locale and breaking CLIs that expect a normal env. Exporting inside the wrapper preserves all inherited vars and adds only PATH.

## Files changed
- `src-tauri/src/binresolve.rs` — `resolve_binary` returns `Option<ResolvedBinary { path, env_path }>`; marker-delimited parsing.
- `src/services/llm.ts` — cache shape becomes `{ path, envPath }`; `runCliShellWrapped` accepts `opts.envPath`; all four call sites updated (codex.complete, claudeCode.complete, probeCodex, probeClaudeCode).
- `src/services/__tests__/llm.spawn.test.ts` — 3 new tests covering env propagation, defensive empty-envPath, and the Settings override path.

## Test plan
- [x] `npx vitest run` — 384/384 tests pass (3 new)
- [x] `cargo test binresolve` — 10/10 tests pass (existing smoke test extended to assert env_path is populated)
- [x] `npm run build` — clean
- [x] `cargo check` — clean
- [ ] **Manual repro** — must launch the built `.app` from Finder, NOT `tauri dev` (dev inherits the parent terminal's full PATH and masks the bug):
  ```
  npm run tauri build
  open src-tauri/target/release/bundle/macos/Keepr.app
  ```
  Then Settings → Local CLI → Codex → "Detect again" → expect green "Codex CLI: detected ✓".
- [ ] Regression check: Claude-Code probe still passes; trigger an actual completion through both providers from the chat surface.
- [ ] Override regression: save a custom path under "Advanced — Set a custom path", confirm probe still passes (validate_binary_path → empty envPath → no export emitted, inherited PATH preserved).

## Out of scope
Pre-existing `$SHELL` exposure for fish/csh/nu users — those shells don't speak `-lic` or `command -v` the same way. Same surface as before this PR; worth a follow-up issue, not a blocker.